### PR TITLE
Add periodic API

### DIFF
--- a/metrics_statistics_msgs/CMakeLists.txt
+++ b/metrics_statistics_msgs/CMakeLists.txt
@@ -29,16 +29,16 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
-        "msg/MetricsMessage.msg"
-        "msg/StatisticDataPoint.msg"
-        "msg/StatisticDataType.msg"
-        )
+  msg/MetricsMessage.msg
+  msg/StatisticDataPoint.msg
+  msg/StatisticDataType.msg
+  )
 
 ## Generate added messages and services with any dependencies listed here
 rosidl_generate_interfaces(${PROJECT_NAME}
-        ${msg_files}
-        DEPENDENCIES builtin_interfaces std_msgs
-        )
+  ${msg_files}
+  DEPENDENCIES builtin_interfaces std_msgs
+  )
 
 ament_export_dependencies(rosidl_default_runtime)
 

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(system_metrics_collector SHARED
   src/system_metrics_collector/collector.cpp
   src/system_metrics_collector/periodic_measurement_node.cpp)
 
-ament_target_dependencies(system_metrics_collector rclcpp)
+ament_target_dependencies(system_metrics_collector rclcpp rcpputils)
 ament_export_libraries(system_metrics_collector)
 
 if(BUILD_TESTING)

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -28,12 +28,14 @@ find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(metrics_statistics_msgs REQUIRED)
 
-set(SOURCES
-  src/moving_average_statistics/moving_average.hpp
+add_library(system_metrics_collector SHARED
   src/moving_average_statistics/moving_average.cpp
   src/moving_average_statistics/types.hpp
-  src/system_metrics_collector/collector.hpp
-  src/system_metrics_collector/collector.cpp)
+  src/system_metrics_collector/collector.cpp
+  src/system_metrics_collector/periodic_measurement_node.cpp)
+
+ament_target_dependencies(system_metrics_collector rclcpp)
+ament_export_libraries(system_metrics_collector)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -42,12 +44,19 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_moving_average_statistics
-    test/moving_average_statistics/test_moving_average_statistics.cpp
-    ${SOURCES})
+    test/moving_average_statistics/test_moving_average_statistics.cpp)
+  target_link_libraries(test_moving_average_statistics system_metrics_collector)
+  ament_target_dependencies(test_moving_average_statistics rclcpp)
 
   ament_add_gtest(test_collector
-    test/system_metrics_collector/test_collector.cpp
-    ${SOURCES})
+    test/system_metrics_collector/test_collector.cpp)
+  target_link_libraries(test_collector system_metrics_collector)
+  ament_target_dependencies(test_collector rclcpp)
+
+  ament_add_gtest(test_periodic_measurement_node
+    test/system_metrics_collector/test_periodic_measurement_node.cpp)
+  target_link_libraries(test_periodic_measurement_node system_metrics_collector)
+  ament_target_dependencies(test_periodic_measurement_node rclcpp)
 
   install(TARGETS
     test_moving_average_statistics
@@ -57,7 +66,10 @@ if(BUILD_TESTING)
     test_collector
     DESTINATION
     lib/${PROJECT_NAME})
-
+  install(TARGETS
+    test_periodic_measurement_node
+    DESTINATION
+    lib/${PROJECT_NAME})
 endif()
 
 ament_package()

--- a/system_metrics_collector/package.xml
+++ b/system_metrics_collector/package.xml
@@ -11,15 +11,18 @@
 
   <build_depend>rclcpp</build_depend>
   <build_depend>rcutils</build_depend>
+  <build_depend>rcpputils</build_depend>
   <build_depend>metrics_statistics_msgs</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rcpputils</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>metrics_statistics_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
+  <test_depend>rcpputils</test_depend>
   <test_depend>rcutils</test_depend>
 
   <export>

--- a/system_metrics_collector/package.xml
+++ b/system_metrics_collector/package.xml
@@ -19,6 +19,8 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rclcpp</test_depend>
+  <test_depend>rcutils</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/system_metrics_collector/src/moving_average_statistics/moving_average.hpp
+++ b/system_metrics_collector/src/moving_average_statistics/moving_average.hpp
@@ -25,6 +25,7 @@
 
 #include "types.hpp"
 
+#include "rcpputils/thread_safety_annotations.hpp"
 
 /**
  *  A class for calculating moving average statistics. This operates in constant memory and constant time. Note:
@@ -49,21 +50,21 @@ public:
    *
    *  @return The arithmetic mean of all data recorded, or NaN if the sample count is 0.
   **/
-  double average() const;
+  double average() const RCPPUTILS_TSA_REQUIRES(mutex);
 
   /**
    *  Returns the maximum value recorded. If size of list is zero, returns NaN.
    *
    *  @return The maximum value recorded, or NaN if size of data is zero.
   **/
-  double max() const;
+  double max() const RCPPUTILS_TSA_REQUIRES(mutex);
 
   /**
    *  Returns the minimum value recorded. If size of list is zero, returns NaN.
    *
    *  @return The minimum value recorded, or NaN if size of data is zero.
   **/
-  double min() const;
+  double min() const RCPPUTILS_TSA_REQUIRES(mutex);
 
   /**
    *  Returns the standard deviation (population) of all data recorded. If size of list is zero, returns NaN.
@@ -73,7 +74,7 @@ public:
    *
    *  @return The standard deviation (population) of all data recorded, or NaN if size of data is zero.
   **/
-  double standardDeviation() const;
+  double standardDeviation() const RCPPUTILS_TSA_REQUIRES(mutex);
 
   /**
    *  Return a StatisticData object, containing average, minimum, maximum, standard deviation (population),
@@ -106,12 +107,11 @@ public:
 
 private:
   mutable std::mutex mutex;
-  // cached values below
-  double average_ = 0;
-  double min_ = std::numeric_limits<double>::max();
-  double max_ = std::numeric_limits<double>::min();
-  double sum_of_square_diff_from_mean_ = 0;
-  uint64_t count_ = 0;
+  double average_ = 0                              RCPPUTILS_TSA_GUARDED_BY(mutex);
+  double min_ = std::numeric_limits<double>::max() RCPPUTILS_TSA_GUARDED_BY(mutex);
+  double max_ = std::numeric_limits<double>::min() RCPPUTILS_TSA_GUARDED_BY(mutex);
+  double sum_of_square_diff_from_mean_ = 0         RCPPUTILS_TSA_GUARDED_BY(mutex);
+  uint64_t count_ = 0                              RCPPUTILS_TSA_GUARDED_BY(mutex);
 };
 
 #endif  // MOVING_AVERAGE_STATISTICS__MOVING_AVERAGE_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.cpp
@@ -23,7 +23,7 @@
 
 bool Collector::start()
 {
-  std::unique_lock<std::recursive_mutex> ulock(mutex);
+  std::unique_lock<std::mutex> ulock(mutex);
   if (started_) {
     return false;
   }
@@ -33,7 +33,7 @@ bool Collector::start()
 
 bool Collector::stop()
 {
-  std::unique_lock<std::recursive_mutex> ulock(mutex);
+  std::unique_lock<std::mutex> ulock(mutex);
   if (!started_) {
     return false;
   }
@@ -61,7 +61,7 @@ void Collector::clearCurrentMeasurements()
 
 bool Collector::isStarted() const
 {
-  std::unique_lock<std::recursive_mutex> ulock(mutex);
+  std::unique_lock<std::mutex> ulock(mutex);
   return started_;
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.cpp
@@ -33,13 +33,16 @@ bool Collector::start()
 
 bool Collector::stop()
 {
-  std::unique_lock<std::mutex> ulock(mutex);
-  if (!started_) {
-    return false;
-  }
-  started_ = false;
+  bool ret = false;
+  {
+    std::unique_lock<std::mutex> ulock(mutex);
+    if (!started_) {
+      return false;
+    }
+    started_ = false;
 
-  const bool ret = setupStop();
+    ret = setupStop();
+  }
   clearCurrentMeasurements();
   return ret;
 }
@@ -65,7 +68,7 @@ bool Collector::isStarted() const
   return started_;
 }
 
-std::string Collector::getStatusString()
+std::string Collector::getStatusString() const
 {
   std::stringstream ss;
   ss << "started=" << (isStarted() ? "true" : "false") <<

--- a/system_metrics_collector/src/system_metrics_collector/collector.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.hpp
@@ -21,6 +21,8 @@
 #include "../moving_average_statistics/moving_average.hpp"
 #include "../moving_average_statistics/types.hpp"
 
+#include "rcpputils/thread_safety_annotations.hpp"
+
 /**
  * Simple class in order to collect observed data and generate statistics for the given observations.
  */
@@ -80,7 +82,7 @@ public:
    *
    * @return a string detailing the current status
    */
-  virtual std::string getStatusString();
+  virtual std::string getStatusString() const;
 
   // todo @dabonnie uptime (once start has been called)
 
@@ -90,20 +92,20 @@ private:
    *
    * @return true if setup was successful, false otherwise.
    */
-  virtual bool setupStart() = 0;
+  virtual bool setupStart() = 0 RCPPUTILS_TSA_REQUIRES(mutex);
 
   /**
    * Override in order to perform necessary teardown.
    *
    * @return true if teardown was successful, false otherwise.
    */
-  virtual bool setupStop() = 0;
+  virtual bool setupStop() = 0 RCPPUTILS_TSA_REQUIRES(mutex);
 
   mutable std::mutex mutex;
 
   MovingAverageStatistics collected_data_;
 
-  bool started_{false};
+  bool started_{false} RCPPUTILS_TSA_GUARDED_BY(mutex);
 };
 
 

--- a/system_metrics_collector/src/system_metrics_collector/collector.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.hpp
@@ -39,14 +39,6 @@ public:
   bool start();
 
   /**
-   * Override in order to perform necessary starting steps. Overridden methods should lock the recursive mutex class
-   * member 'mutex'
-   *
-   * @return true if setup was successful, false otherwise.
-   */
-  virtual bool setupStart() = 0;
-
-  /**
    * Stop collecting data. Meant to be a teardown method (before destruction, but should place the
    * class in a restartable state, i.e., start can be called to be able to resume collection.
    *
@@ -57,15 +49,8 @@ public:
   bool stop();
 
   /**
-   * Override in order to perform necessary teardown. Overridden methods should lock the recursive mutex class
-   * member 'mutex'
-   *
-   * @return true if teardown was successful, false otherwise.
-   */
-  virtual bool setupStop() = 0;
-
-  /**
-   * Add an observed measurement.
+   * Add an observed measurement. This aggregates the measurement and calculates statistics
+   * via the moving_average class.
    *
    * @param the measurement observed
    */
@@ -99,11 +84,25 @@ public:
 
   // todo @dabonnie uptime (once start has been called)
 
-protected:
-  mutable std::recursive_mutex mutex;  // recursive for child classes
-
 private:
+  /**
+   * Override in order to perform necessary starting steps.
+   *
+   * @return true if setup was successful, false otherwise.
+   */
+  virtual bool setupStart() = 0;
+
+  /**
+   * Override in order to perform necessary teardown.
+   *
+   * @return true if teardown was successful, false otherwise.
+   */
+  virtual bool setupStop() = 0;
+
+  mutable std::mutex mutex;
+
   MovingAverageStatistics collected_data_;
+
   bool started_{false};
 };
 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -55,7 +55,7 @@ bool PeriodicMeasurementNode::setupStop()
   return true;
 }
 
-std::string PeriodicMeasurementNode::getStatusString()
+std::string PeriodicMeasurementNode::getStatusString() const
 {
   std::stringstream ss;
   ss << "name=" << get_name() <<

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -23,7 +23,7 @@
 
 PeriodicMeasurementNode::PeriodicMeasurementNode(
   const std::string & name,
-  const std::chrono::milliseconds & measurement_period,
+  const std::chrono::milliseconds measurement_period,
   const std::string & publishing_topic)
 : Node(name),
   measurement_period_(measurement_period),

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -1,0 +1,75 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "periodic_measurement_node.hpp"
+
+#include <chrono>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+
+PeriodicMeasurementNode::PeriodicMeasurementNode(
+  const std::string & name,
+  const std::chrono::milliseconds & measurement_period,
+  const std::string & publishing_topic)
+: Node(name),
+  measurement_period_(measurement_period),
+  publishing_topic_(publishing_topic)
+{}
+
+bool PeriodicMeasurementNode::setupStart()
+{
+  std::unique_lock<std::recursive_mutex> ulock(mutex);
+
+  if (!measurement_timer_) {
+    RCLCPP_DEBUG(this->get_logger(), "creating timer");
+
+    measurement_timer_ = this->create_wall_timer(
+      measurement_period_,
+      std::bind(&PeriodicMeasurementNode::performPeriodicMeasurement, this));
+
+  } else {
+    RCLCPP_WARN(this->get_logger(), "setupStart: measurement_timer_ already exists!");
+  }
+  return true;
+}
+
+bool PeriodicMeasurementNode::setupStop()
+{
+  std::unique_lock<std::recursive_mutex> ulock(mutex);
+
+  if (measurement_timer_) {
+    measurement_timer_->cancel();
+    measurement_timer_ = nullptr;
+  }
+  return true;
+}
+
+void PeriodicMeasurementNode::performPeriodicMeasurement()
+{
+  std::unique_lock<std::recursive_mutex> ulock(mutex);
+  periodicMeasurement();
+}
+
+std::string PeriodicMeasurementNode::getStatusString()
+{
+  std::stringstream ss;
+  ss << "name=" << get_name() <<
+    ", measurement_period=" << std::to_string(measurement_period_.count()) << "ms" <<
+    ", publishing_topic=" << publishing_topic_ <<
+    ", " << Collector::getStatusString();
+  return ss.str();
+}

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -1,0 +1,87 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef SYSTEM_METRICS_COLLECTOR__PERIODIC_MEASUREMENT_NODE_HPP_
+#define SYSTEM_METRICS_COLLECTOR__PERIODIC_MEASUREMENT_NODE_HPP_
+
+#include <chrono>
+#include <string>
+
+#include "collector.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
+/**
+ * Class which makes periodic measurements, using a ROS2 timer.
+ */
+class PeriodicMeasurementNode : public Collector, public rclcpp::Node
+{
+public:
+  /**
+   * Construct a PeriodicMeasurementNode.
+   *
+   * @param name the name of this node
+   * @param topic the topic for publishing data
+   * @param measurement_period
+   */
+  explicit PeriodicMeasurementNode(
+    const std::string & name,
+    const std::chrono::milliseconds & measurement_period,
+    const std::string & topic);  // todo @dbbonnie think about a default topic
+
+  virtual ~PeriodicMeasurementNode() = default;
+
+  /**
+   * Creates a ROS2 timer with a period of measurement_period_.
+   *
+   * @return if setup was successful
+   */
+  bool setupStart() override;
+
+  /**
+   * Stops the ROS2 timer
+   *
+   * @return if teardown was successful
+   */
+  bool setupStop() override;
+
+  /**
+   * Periodically calls this method, via the ROS2 timer, in order to perform a
+   * measurement. The measurement should be defined in the periodicMeasurement method.
+   */
+  void performPeriodicMeasurement();
+
+  /**
+   * Return a pretty printed status representation of this class
+   *
+   * @return a string detailing the current status
+   */
+  std::string getStatusString() override;
+
+protected:
+  /**
+   * Override this method to perform a measurement. This is called via performPeriodicMeasurement
+   * with the period defined in the constructor.
+   */
+  virtual void periodicMeasurement() = 0;
+
+private:
+  std::string publishing_topic_;
+  std::chrono::milliseconds measurement_period_;
+  rclcpp::TimerBase::SharedPtr measurement_timer_{nullptr};
+};
+
+
+#endif  // SYSTEM_METRICS_COLLECTOR__PERIODIC_MEASUREMENT_NODE_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -36,12 +36,26 @@ public:
    * @param topic the topic for publishing data
    * @param measurement_period
    */
-  explicit PeriodicMeasurementNode(
+  PeriodicMeasurementNode(
     const std::string & name,
     const std::chrono::milliseconds & measurement_period,
     const std::string & topic);  // todo @dbbonnie think about a default topic
 
   virtual ~PeriodicMeasurementNode() = default;
+
+  /**
+   * Return a pretty printed status representation of this class
+   *
+   * @return a string detailing the current status
+   */
+  std::string getStatusString() override;
+
+private:
+  /**
+   * Override this method to perform a single measurement. This is called via performPeriodicMeasurement
+   * with the period defined in the constructor.
+   */
+  virtual void periodicMeasurement() = 0;
 
   /**
    * Creates a ROS2 timer with a period of measurement_period_.
@@ -57,30 +71,9 @@ public:
    */
   bool setupStop() override;
 
-  /**
-   * Periodically calls this method, via the ROS2 timer, in order to perform a
-   * measurement. The measurement should be defined in the periodicMeasurement method.
-   */
-  void performPeriodicMeasurement();
-
-  /**
-   * Return a pretty printed status representation of this class
-   *
-   * @return a string detailing the current status
-   */
-  std::string getStatusString() override;
-
-protected:
-  /**
-   * Override this method to perform a measurement. This is called via performPeriodicMeasurement
-   * with the period defined in the constructor.
-   */
-  virtual void periodicMeasurement() = 0;
-
-private:
   std::string publishing_topic_;
   std::chrono::milliseconds measurement_period_;
-  rclcpp::TimerBase::SharedPtr measurement_timer_{nullptr};
+  rclcpp::TimerBase::SharedPtr measurement_timer_;
 };
 
 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -48,7 +48,7 @@ public:
    *
    * @return a string detailing the current status
    */
-  std::string getStatusString() override;
+  std::string getStatusString() const override;
 
 private:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -38,7 +38,7 @@ public:
    */
   PeriodicMeasurementNode(
     const std::string & name,
-    const std::chrono::milliseconds & measurement_period,
+    const std::chrono::milliseconds measurement_period,
     const std::string & topic);  // todo @dbbonnie think about a default topic
 
   virtual ~PeriodicMeasurementNode() = default;

--- a/system_metrics_collector/test/moving_average_statistics/test_moving_average_statistics.cpp
+++ b/system_metrics_collector/test/moving_average_statistics/test_moving_average_statistics.cpp
@@ -58,7 +58,6 @@ protected:
 };
 
 TEST_F(MovingAverageStatisticsTestFixture, sanity) {
-  ASSERT_TRUE(true);
   ASSERT_NE(moving_average_statistics, nullptr);
 }
 
@@ -189,12 +188,4 @@ TEST(MovingAverageStatisticsTest, test_pretty_printing) {
   stats.addMeasurement(1);
   ASSERT_EQ("avg=1.000000, min=1.000000, max=1.000000, std_dev=0.000000, count=1",
     statisticsDataToString(stats.getStatistics()));
-}
-
-int main(int argc, char ** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  // run with 'time ./test_moving_average_statistics --gtest_repeat=2000
-  //   --gtest_shuffle --gtest_break_on_failure'
-  return RUN_ALL_TESTS();
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
@@ -28,11 +28,11 @@ class TestCollector : public Collector
 public:
   TestCollector() = default;
   virtual ~TestCollector() = default;
-  bool start() override
+  bool setupStart() override
   {
     return true;
   }
-  bool stop() override
+  bool setupStop() override
   {
     this->clearCurrentMeasurements();
     return true;
@@ -60,7 +60,6 @@ protected:
 };
 
 TEST_F(CollectorTestFixure, sanity) {
-  ASSERT_TRUE(true);
   ASSERT_NE(test_collector, nullptr);
 }
 
@@ -77,4 +76,14 @@ TEST_F(CollectorTestFixure, test_add_and_clear_measurement) {
   ASSERT_TRUE(std::isnan(stats.max));
   ASSERT_TRUE(std::isnan(stats.standard_deviation));
   ASSERT_EQ(0, stats.sample_count);
+}
+
+TEST_F(CollectorTestFixure, test_start_and_stop) {
+  ASSERT_FALSE(test_collector->isStarted());
+  ASSERT_EQ("started=false, avg=nan, min=nan, max=nan, std_dev=nan, count=0",
+    test_collector->getStatusString());
+  ASSERT_TRUE(test_collector->start());
+  ASSERT_TRUE(test_collector->isStarted());
+  ASSERT_EQ("started=true, avg=nan, min=nan, max=nan, std_dev=nan, count=0",
+    test_collector->getStatusString());
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -1,0 +1,141 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <memory>
+#include <mutex>
+
+#include "../../src/system_metrics_collector/collector.hpp"
+#include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
+#include "../../src/moving_average_statistics/types.hpp"
+
+/**
+ * Simple extension to test basic functionality
+ */
+class TestPeriodicMeasurementNode : public PeriodicMeasurementNode
+{
+public:
+  TestPeriodicMeasurementNode(
+    const std::string name,
+    const std::chrono::milliseconds & measurement_period,
+    const std::string & publishing_topic)
+  : PeriodicMeasurementNode(name, measurement_period, publishing_topic)
+  {}
+  virtual ~TestPeriodicMeasurementNode() = default;
+
+private:
+  void periodicMeasurement() override
+  {
+    std::unique_lock<std::recursive_mutex> ulock(mutex);
+    sum += 1;
+    acceptData(static_cast<double>(sum.load()));
+  }
+  std::atomic<int> sum{0};
+  std::condition_variable_any cv;
+};
+
+/**
+ * Test fixture
+ */
+class PeriodicMeasurementTestFixure : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    const char * const argv = "d";
+    rclcpp::init(1, &argv);
+
+    test_periodic_measurer = std::make_shared<TestPeriodicMeasurementNode>("test_periodic_node",
+        std::chrono::milliseconds(50), "test_topic");
+
+    ASSERT_FALSE(test_periodic_measurer->isStarted());
+
+    const StatisticData data = test_periodic_measurer->getStatisticsResults();
+    ASSERT_TRUE(std::isnan(data.average));
+    ASSERT_TRUE(std::isnan(data.min));
+    ASSERT_TRUE(std::isnan(data.max));
+    ASSERT_TRUE(std::isnan(data.standard_deviation));
+    ASSERT_EQ(0, data.sample_count);
+  }
+
+  void TearDown() override
+  {
+    test_periodic_measurer->stop();
+    test_periodic_measurer.reset();
+    rclcpp::shutdown();
+  }
+
+protected:
+  std::shared_ptr<TestPeriodicMeasurementNode> test_periodic_measurer;
+};
+
+TEST_F(PeriodicMeasurementTestFixure, sanity) {
+  ASSERT_NE(test_periodic_measurer, nullptr);
+  ASSERT_EQ("name=test_periodic_node, publishing_topic=test_topic, measurement_period=50ms, "
+    "started=false, avg=nan, min=nan, max=nan, std_dev=nan, count=0",
+    test_periodic_measurer->getStatusString());
+}
+
+TEST_F(PeriodicMeasurementTestFixure, test_measurement_manually) {
+  ASSERT_NE(test_periodic_measurer, nullptr);
+
+  test_periodic_measurer->performPeriodicMeasurement();
+
+  StatisticData data = test_periodic_measurer->getStatisticsResults();
+  ASSERT_FALSE(std::isnan(data.average));
+  ASSERT_FALSE(std::isnan(data.min));
+  ASSERT_FALSE(std::isnan(data.max));
+  ASSERT_FALSE(std::isnan(data.standard_deviation));
+  ASSERT_EQ(1, data.sample_count);
+}
+
+TEST_F(PeriodicMeasurementTestFixure, test_start_and_stop) {
+  ASSERT_TRUE(true);
+  ASSERT_NE(test_periodic_measurer, nullptr);
+  ASSERT_FALSE(test_periodic_measurer->isStarted());
+
+
+  const bool start_success = test_periodic_measurer->start();
+  ASSERT_TRUE(start_success);
+  ASSERT_TRUE(test_periodic_measurer->isStarted());
+
+  std::promise<bool> empty_promise;
+  std::shared_future<bool> dummy_future = empty_promise.get_future();
+
+  rclcpp::executors::SingleThreadedExecutor ex;
+  ex.add_node(test_periodic_measurer);
+  ex.spin_until_future_complete(dummy_future, std::chrono::milliseconds(250));
+
+  StatisticData data = test_periodic_measurer->getStatisticsResults();
+  ASSERT_EQ(3, data.average);
+  ASSERT_EQ(1, data.min);
+  ASSERT_EQ(5, data.max);
+  ASSERT_FALSE(std::isnan(data.standard_deviation));
+  ASSERT_EQ(5, data.sample_count);
+
+  const bool stop_success = test_periodic_measurer->stop();
+  ASSERT_TRUE(stop_success);
+  ASSERT_FALSE(test_periodic_measurer->isStarted());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -39,13 +39,14 @@ public:
   {}
   virtual ~TestPeriodicMeasurementNode() = default;
 
-private:
+  // made public to manually test
   void periodicMeasurement() override
   {
-    std::unique_lock<std::recursive_mutex> ulock(mutex);
     sum += 1;
     acceptData(static_cast<double>(sum.load()));
   }
+
+private:
   std::atomic<int> sum{0};
   std::condition_variable_any cv;
 };
@@ -87,15 +88,15 @@ protected:
 
 TEST_F(PeriodicMeasurementTestFixure, sanity) {
   ASSERT_NE(test_periodic_measurer, nullptr);
-  ASSERT_EQ("name=test_periodic_node, publishing_topic=test_topic, measurement_period=50ms, "
-    "started=false, avg=nan, min=nan, max=nan, std_dev=nan, count=0",
+  ASSERT_EQ("name=test_periodic_node, measurement_period=50ms, publishing_topic=test_topic,"
+    " started=false, avg=nan, min=nan, max=nan, std_dev=nan, count=0",
     test_periodic_measurer->getStatusString());
 }
 
 TEST_F(PeriodicMeasurementTestFixure, test_measurement_manually) {
   ASSERT_NE(test_periodic_measurer, nullptr);
 
-  test_periodic_measurer->performPeriodicMeasurement();
+  test_periodic_measurer->periodicMeasurement();
 
   StatisticData data = test_periodic_measurer->getStatisticsResults();
   ASSERT_FALSE(std::isnan(data.average));

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -25,11 +25,13 @@
 #include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
 #include "../../src/moving_average_statistics/types.hpp"
 
-
+namespace
+{
 static constexpr const std::chrono::milliseconds TEST_LENGTH =
   std::chrono::milliseconds(250);
 static constexpr const std::chrono::milliseconds TEST_PERIOD =
   std::chrono::milliseconds(50);
+}
 
 /**
  * Simple extension to test basic functionality
@@ -39,7 +41,7 @@ class TestPeriodicMeasurementNode : public PeriodicMeasurementNode
 public:
   TestPeriodicMeasurementNode(
     const std::string & name,
-    const std::chrono::milliseconds & measurement_period,
+    const std::chrono::milliseconds measurement_period,
     const std::string & publishing_topic)
   : PeriodicMeasurementNode(name, measurement_period, publishing_topic)
   {}


### PR DESCRIPTION
Add relevant class and abstractions to perform periodic measurements.

Note: the Collector and Periodic patter follows previous work from ROS CloudWatch CEs and ROS2 QoS System tests.