### PR TITLE
Add namespaces

### DIFF
--- a/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
+++ b/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
@@ -24,6 +24,8 @@
 #include "moving_average.hpp"
 #include "types.hpp"
 
+namespace moving_average_statistics
+{
 
 double MovingAverageStatistics::average() const
 {
@@ -94,3 +96,5 @@ uint64_t MovingAverageStatistics::getCount() const
   std::lock_guard<std::mutex> guard(mutex);
   return count_;
 }
+
+}  // namespace moving_average_statistics

--- a/system_metrics_collector/src/moving_average_statistics/moving_average.hpp
+++ b/system_metrics_collector/src/moving_average_statistics/moving_average.hpp
@@ -27,6 +27,9 @@
 
 #include "rcpputils/thread_safety_annotations.hpp"
 
+namespace moving_average_statistics
+{
+
 /**
  *  A class for calculating moving average statistics. This operates in constant memory and constant time. Note:
  *  reset() must be called manually in order to start a new measurement window.
@@ -114,5 +117,7 @@ private:
   double sum_of_square_diff_from_mean_ = 0         RCPPUTILS_TSA_GUARDED_BY(mutex);
   uint64_t count_ = 0                              RCPPUTILS_TSA_GUARDED_BY(mutex);
 };
+
+}  // namespace moving_average_statistics
 
 #endif  // MOVING_AVERAGE_STATISTICS__MOVING_AVERAGE_HPP_

--- a/system_metrics_collector/src/moving_average_statistics/types.hpp
+++ b/system_metrics_collector/src/moving_average_statistics/types.hpp
@@ -18,6 +18,9 @@
 #include <sstream>
 #include <string>
 
+namespace moving_average_statistics
+{
+
 /**
  *  A container for statistics data results for a set of recorded observations.
  */
@@ -45,5 +48,7 @@ static std::string statisticsDataToString(const StatisticData & results)
     results.standard_deviation) << ", count=" << std::to_string(results.sample_count);
   return ss.str();
 }
+
+}  // namespace moving_average_statistics
 
 #endif  // MOVING_AVERAGE_STATISTICS__TYPES_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.cpp
@@ -52,7 +52,7 @@ void Collector::acceptData(const double measurement)
   collected_data_.addMeasurement(measurement);
 }
 
-StatisticData Collector::getStatisticsResults() const
+moving_average_statistics::StatisticData Collector::getStatisticsResults() const
 {
   return collected_data_.getStatistics();
 }

--- a/system_metrics_collector/src/system_metrics_collector/collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.cpp
@@ -21,6 +21,9 @@
 #include "../../src/moving_average_statistics/moving_average.hpp"
 #include "../../src/moving_average_statistics/types.hpp"
 
+namespace system_metrics_collector
+{
+
 bool Collector::start()
 {
   std::unique_lock<std::mutex> ulock(mutex);
@@ -75,3 +78,5 @@ std::string Collector::getStatusString() const
     ", " << statisticsDataToString(getStatisticsResults());
   return ss.str();
 }
+
+}  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/collector.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.hpp
@@ -23,6 +23,8 @@
 
 #include "rcpputils/thread_safety_annotations.hpp"
 
+// namespace system_metrics_collector {
+
 /**
  * Simple class in order to collect observed data and generate statistics for the given observations.
  */
@@ -63,7 +65,7 @@ public:
    *
    * @return the StatisticData for all the observed measurements
    */
-  virtual StatisticData getStatisticsResults() const;
+  virtual moving_average_statistics::StatisticData getStatisticsResults() const;
 
   /**
    * Clear / reset all current measurements.
@@ -103,10 +105,11 @@ private:
 
   mutable std::mutex mutex;
 
-  MovingAverageStatistics collected_data_;
+  moving_average_statistics::MovingAverageStatistics collected_data_;
 
   bool started_{false} RCPPUTILS_TSA_GUARDED_BY(mutex);
 };
 
+// }  // namespace system_metrics_collector
 
 #endif  // SYSTEM_METRICS_COLLECTOR__COLLECTOR_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/collector.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.hpp
@@ -23,7 +23,8 @@
 
 #include "rcpputils/thread_safety_annotations.hpp"
 
-// namespace system_metrics_collector {
+namespace system_metrics_collector
+{
 
 /**
  * Simple class in order to collect observed data and generate statistics for the given observations.
@@ -110,6 +111,6 @@ private:
   bool started_{false} RCPPUTILS_TSA_GUARDED_BY(mutex);
 };
 
-// }  // namespace system_metrics_collector
+}  // namespace system_metrics_collector
 
 #endif  // SYSTEM_METRICS_COLLECTOR__COLLECTOR_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -32,7 +32,7 @@ constexpr const char CPU_LABEL[] = "cpu";
 namespace system_metrics_collector
 {
 
-system_metrics_collector::ProcCpuData processLine(const std::string & stat_cpu_line)
+system_metrics_collector::ProcCpuData processStatCpuLine(const std::string & stat_cpu_line)
 {
   system_metrics_collector::ProcCpuData parsed_data;
 
@@ -113,7 +113,7 @@ system_metrics_collector::ProcCpuData LinuxCpuMeasurementNode::makeSingleMeasure
     RCLCPP_ERROR(this->get_logger(), "unable to get cpu line from file");
     return system_metrics_collector::ProcCpuData();
   } else {
-    return processLine(line);
+    return processStatCpuLine(line);
   }
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -23,13 +23,16 @@
 #include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
 #include "../../src/system_metrics_collector/proc_cpu_data.hpp"
 
+namespace system_metrics_collector
+{
+
 /**
  * Parse a line read from /proc/stat
  *
  * @param stat_cpu_line a line from /proc/stat
  * @return ProcCpuData struct populated if parsed, otherwise empty
  */
-ProcCpuData processLine(const std::string & stat_cpu_line);
+system_metrics_collector::ProcCpuData processLine(const std::string & stat_cpu_line);
 
 /**
  * Compute the percentage of CPU active.
@@ -39,14 +42,14 @@ ProcCpuData processLine(const std::string & stat_cpu_line);
  * @return percentage of CPU active
  */
 double computeCpuActivePercentage(
-  const ProcCpuData & measurement1,
-  const ProcCpuData & measurement2);
+  const system_metrics_collector::ProcCpuData & measurement1,
+  const system_metrics_collector::ProcCpuData & measurement2);
 
 /**
  * Node that periodically calculates the % of active CPU by
  * reading /proc/stat.
  */
-class LinuxCpuMeasurementNode : public PeriodicMeasurementNode
+class LinuxCpuMeasurementNode : public system_metrics_collector::PeriodicMeasurementNode
 {
 public:
   /**
@@ -80,13 +83,15 @@ private:
    *
    * @return ProcCpuData the measurement made
    */
-  virtual ProcCpuData makeSingleMeasurement();
+  virtual system_metrics_collector::ProcCpuData makeSingleMeasurement();
 
   /**
    * The cached measurement used in order to perform the CPU active
    * percentage.
    */
-  ProcCpuData last_measurement_;
+  system_metrics_collector::ProcCpuData last_measurement_;
 };
+
+}  // namespace system_metrics_collector
 
 #endif  // SYSTEM_METRICS_COLLECTOR__LINUX_CPU_MEASUREMENT_NODE_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -32,7 +32,7 @@ namespace system_metrics_collector
  * @param stat_cpu_line a line from /proc/stat
  * @return ProcCpuData struct populated if parsed, otherwise empty
  */
-system_metrics_collector::ProcCpuData processLine(const std::string & stat_cpu_line);
+system_metrics_collector::ProcCpuData processStatCpuLine(const std::string & stat_cpu_line);
 
 /**
  * Compute the percentage of CPU active.

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -33,8 +33,8 @@ constexpr const char EMPTY_FILE[] = "";
 constexpr const int INVALID_MEMORY_SAMPLE = -1;
 }  // namespace
 
-namespace system_metrics_collector {
-
+namespace system_metrics_collector
+{
 
 std::string readFileToString(const std::string & file_name)
 {

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -33,15 +33,14 @@ constexpr const char EMPTY_FILE[] = "";
 constexpr const int INVALID_MEMORY_SAMPLE = -1;
 }  // namespace
 
-namespace system_metrics_collector
-{
+namespace system_metrics_collector {
 
 
-std::string readFile(const std::string & file_name)
+std::string readFileToString(const std::string & file_name)
 {
   std::ifstream file_to_read(file_name);
   if (!file_to_read.good()) {
-    RCUTILS_LOG_ERROR_NAMED("readFile", "unable to parse file %s", file_name.c_str());
+    RCUTILS_LOG_ERROR_NAMED("readFileToString", "unable to parse file %s", file_name.c_str());
     return EMPTY_FILE;
   }
 
@@ -51,7 +50,7 @@ std::string readFile(const std::string & file_name)
   return to_return;
 }
 
-double processLines(const std::string & lines)
+double processMemInfoLines(const std::string & lines)
 {
   std::istringstream process_lines_stream(lines);
   if (!process_lines_stream.good()) {
@@ -73,13 +72,13 @@ double processLines(const std::string & lines)
     if (!line.compare(0, strlen(MEM_TOTAL), MEM_TOTAL)) {
       parse_line >> tlabel;
       if (!parse_line.good()) {
-        RCUTILS_LOG_ERROR_NAMED("processLines", "unable to parse %s label", MEM_TOTAL);
+        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s label", MEM_TOTAL);
         return std::nan("");
       }
 
       parse_line >> total;
       if (!parse_line.good()) {
-        RCUTILS_LOG_ERROR_NAMED("processLines", "unable to parse %s value", MEM_TOTAL);
+        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s value", MEM_TOTAL);
         return std::nan("");
       }
     } else if (!line.compare(0, strlen(MEM_AVAILABLE), MEM_AVAILABLE)) {
@@ -87,13 +86,13 @@ double processLines(const std::string & lines)
 
       parse_line >> tlabel;
       if (!parse_line.good()) {
-        RCUTILS_LOG_ERROR_NAMED("processLines", "unable to parse %s label", MEM_AVAILABLE);
+        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s label", MEM_AVAILABLE);
         return std::nan("");
       }
 
       parse_line >> available;
       if (!parse_line.good()) {
-        RCUTILS_LOG_ERROR_NAMED("processLines", "unable to parse %s value", MEM_AVAILABLE);
+        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s value", MEM_AVAILABLE);
         return std::nan("");
       }
       break;  // no need to parse other lines after this label
@@ -121,8 +120,8 @@ double LinuxMemoryMeasurementNode::periodicMeasurement()
   if (!stat_file.good()) {
     return std::nan("");
   }
-  auto read_string = readFile(PROC_STAT_FILE);
-  return processLines(read_string);
+  auto read_string = readFileToString(PROC_STAT_FILE);
+  return processMemInfoLines(read_string);
 }
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -33,6 +33,10 @@ constexpr const char EMPTY_FILE[] = "";
 constexpr const int INVALID_MEMORY_SAMPLE = -1;
 }  // namespace
 
+namespace system_metrics_collector
+{
+
+
 std::string readFile(const std::string & file_name)
 {
   std::ifstream file_to_read(file_name);
@@ -120,3 +124,5 @@ double LinuxMemoryMeasurementNode::periodicMeasurement()
   auto read_string = readFile(PROC_STAT_FILE);
   return processLines(read_string);
 }
+
+}  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -30,7 +30,7 @@ namespace system_metrics_collector
  * @param file_name the file to be read
  * @return the file to be read's contents as a std::string
  */
-std::string readFile(const std::string & file_name);
+std::string readFileToString(const std::string & file_name);
 
 /**
  * Process input lines from the /proc/meminfo file. The expected format to
@@ -44,7 +44,7 @@ std::string readFile(const std::string & file_name);
  * @return the percentage of memory used, specifically
  * (MemTotal - MemAvailable) / MemTotal * 100.0
  */
-double processLines(const std::string & lines);
+double processMemInfoLines(const std::string & lines);
 
 /**
  * Node that periodically measures the percentage of RAM used

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -20,6 +20,9 @@
 
 #include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
 
+namespace system_metrics_collector
+{
+
 /**
  * Read the contents of the input filename into a string. Helper function
  * for parsing.
@@ -48,7 +51,7 @@ double processLines(const std::string & lines);
  * by a linux system. Specifically, the values used to make
  * this measurement are obtained from /proc/meminfo.
  */
-class LinuxMemoryMeasurementNode : public PeriodicMeasurementNode
+class LinuxMemoryMeasurementNode : public system_metrics_collector::PeriodicMeasurementNode
 {
 public:
   /**
@@ -78,5 +81,7 @@ protected:
    */
   double periodicMeasurement() override;
 };
+
+}  // namespace system_metrics_collector
 
 #endif  // SYSTEM_METRICS_COLLECTOR__LINUX_MEMORY_MEASUREMENT_NODE_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -36,13 +36,13 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  auto cpu_node = std::make_shared<LinuxCpuMeasurementNode>(
+  auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
     "linuxCpuCollector",
     std::chrono::milliseconds(1000),
     "not_publishing_yet",
     std::chrono::milliseconds(1000 * 60));
 
-  auto mem_node = std::make_shared<LinuxMemoryMeasurementNode>(
+  auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector",
     std::chrono::milliseconds(1000),
     "not_publishing_yet",

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -20,6 +20,9 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+namespace system_metrics_collector
+{
+
 /* static */ constexpr const std::chrono::milliseconds PeriodicMeasurementNode::
 DEFAULT_PUBLISH_WINDOW;
 
@@ -100,3 +103,5 @@ void PeriodicMeasurementNode::performPeriodicMeasurement()
   acceptData(measurement);
   RCLCPP_DEBUG(this->get_logger(), getStatusString());
 }
+
+}  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -23,10 +23,13 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+namespace system_metrics_collector
+{
+
 /**
  * Class which makes periodic measurements, using a ROS2 timer.
  */
-class PeriodicMeasurementNode : public Collector, public rclcpp::Node
+class PeriodicMeasurementNode : public system_metrics_collector::Collector, public rclcpp::Node
 {
 public:
   static constexpr const std::chrono::milliseconds DEFAULT_PUBLISH_WINDOW =
@@ -107,5 +110,7 @@ private:
   rclcpp::TimerBase::SharedPtr measurement_timer_;
   rclcpp::TimerBase::SharedPtr publish_timer_;
 };
+
+}  // namespace system_metrics_collector
 
 #endif  // SYSTEM_METRICS_COLLECTOR__PERIODIC_MEASUREMENT_NODE_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.cpp
@@ -17,6 +17,9 @@
 
 #include "proc_cpu_data.hpp"
 
+namespace system_metrics_collector
+{
+
 /*static*/ constexpr const char ProcCpuData::EMPTY_LABEL[];
 
 size_t ProcCpuData::getIdleTime() const
@@ -54,3 +57,5 @@ bool ProcCpuData::isMeasurementEmpty() const
 {
   return cpu_label == ProcCpuData::EMPTY_LABEL;
 }
+
+}  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.hpp
@@ -19,6 +19,9 @@
 #include <sstream>
 #include <string>
 
+namespace system_metrics_collector
+{
+
 /**
  * Enum representing each item in a /proc/stat cpu line
  */
@@ -85,5 +88,7 @@ public:
    */
   std::array<int, static_cast<int>(ProcCpuStates::kNumProcCpuStates)> times{};
 };
+
+}  // namespace system_metrics_collector
 
 #endif  // SYSTEM_METRICS_COLLECTOR__PROC_CPU_DATA_HPP_

--- a/system_metrics_collector/test/moving_average_statistics/test_moving_average_statistics.cpp
+++ b/system_metrics_collector/test/moving_average_statistics/test_moving_average_statistics.cpp
@@ -41,7 +41,8 @@ class MovingAverageStatisticsTestFixture : public ::testing::Test
 public:
   void SetUp() override
   {
-    moving_average_statistics = std::make_unique<MovingAverageStatistics>();
+    moving_average_statistics =
+      std::make_unique<moving_average_statistics::MovingAverageStatistics>();
 
     for (double d : TEST_DATA) {
       moving_average_statistics->addMeasurement(d);
@@ -56,14 +57,15 @@ public:
   }
 
 protected:
-  std::unique_ptr<MovingAverageStatistics> moving_average_statistics = nullptr;
+  std::unique_ptr<moving_average_statistics::MovingAverageStatistics> moving_average_statistics =
+    nullptr;
   int expected_count = 0;
 };
 
 TEST_F(MovingAverageStatisticsTestFixture, test_add_nan_ignore) {
-  auto stats1 = statisticsDataToString(moving_average_statistics->getStatistics());
+  const auto stats1 = statisticsDataToString(moving_average_statistics->getStatistics());
   moving_average_statistics->addMeasurement(std::nan(""));
-  auto stats2 = statisticsDataToString(moving_average_statistics->getStatistics());
+  const auto stats2 = statisticsDataToString(moving_average_statistics->getStatistics());
   ASSERT_EQ(stats1, stats2);
 }
 
@@ -88,27 +90,27 @@ TEST_F(MovingAverageStatisticsTestFixture, test_standard_deviation) {
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_average_empty) {
-  MovingAverageStatistics empty;
+  moving_average_statistics::MovingAverageStatistics empty;
   ASSERT_TRUE(std::isnan(empty.average()));
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_maximum_empty) {
-  MovingAverageStatistics empty;
+  moving_average_statistics::MovingAverageStatistics empty;
   ASSERT_TRUE(std::isnan(empty.max()));
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_minimum_empty) {
-  MovingAverageStatistics empty;
+  moving_average_statistics::MovingAverageStatistics empty;
   ASSERT_TRUE(std::isnan(empty.min()));
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_stddev_empty) {
-  MovingAverageStatistics empty;
+  moving_average_statistics::MovingAverageStatistics empty;
   ASSERT_TRUE(std::isnan(empty.standardDeviation()));
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_count_empty) {
-  MovingAverageStatistics empty;
+  moving_average_statistics::MovingAverageStatistics empty;
   ASSERT_EQ(0, empty.getCount());
 }
 
@@ -191,11 +193,11 @@ TEST_F(MovingAverageStatisticsTestFixture, test_thread_safe) {
 }
 
 TEST(MovingAverageStatisticsTest, test_pretty_printing) {
-  StatisticData data;
+  moving_average_statistics::StatisticData data;
   ASSERT_EQ("avg=nan, min=nan, max=nan, std_dev=nan, count=0", statisticsDataToString(data));
 
-  MovingAverageStatistics stats;
+  moving_average_statistics::MovingAverageStatistics stats;
   stats.addMeasurement(1);
   ASSERT_EQ("avg=1.000000, min=1.000000, max=1.000000, std_dev=0.000000, count=1",
-    statisticsDataToString(stats.getStatistics()));
+    moving_average_statistics::statisticsDataToString(stats.getStatistics()));
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
@@ -23,7 +23,7 @@
 /**
  * Simple extension to test basic functionality
  */
-class TestCollector : public Collector
+class TestCollector : public system_metrics_collector::Collector
 {
 public:
   TestCollector() = default;

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -57,9 +57,9 @@ private:
     first = !first;
 
     if (first) {
-      return system_metrics_collector::processLine(proc_sample_1);
+      return system_metrics_collector::processStatCpuLine(proc_sample_1);
     } else {
-      return system_metrics_collector::processLine(proc_sample_2);
+      return system_metrics_collector::processStatCpuLine(proc_sample_2);
     }
   }
 
@@ -109,7 +109,7 @@ TEST_F(LinuxCpuMeasurementTestFixture, testManualMeasurement) {
 
 TEST(LinuxCpuMeasurementTest, testParseProcLine)
 {
-  auto parsed_data = system_metrics_collector::processLine(proc_sample_1);
+  auto parsed_data = system_metrics_collector::processStatCpuLine(proc_sample_1);
 
   ASSERT_EQ("cpu", parsed_data.cpu_label);
   ASSERT_EQ(22451232, parsed_data.times[0]);
@@ -129,8 +129,8 @@ TEST(LinuxCpuMeasurementTest, testParseProcLine)
 
 TEST(LinuxCpuMeasurementTest, testCalculateCpuActivePercentage)
 {
-  auto parsed_data1 = system_metrics_collector::processLine(proc_sample_1);
-  auto parsed_data2 = system_metrics_collector::processLine(proc_sample_2);
+  auto parsed_data1 = system_metrics_collector::processStatCpuLine(proc_sample_1);
+  auto parsed_data2 = system_metrics_collector::processStatCpuLine(proc_sample_2);
 
   auto p = computeCpuActivePercentage(parsed_data1, parsed_data2);
   ASSERT_DOUBLE_EQ(CPU_ACTIVE_PERCENTAGE, p);

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -78,7 +78,8 @@ public:
 
     ASSERT_FALSE(test_measure_linux_cpu->isStarted());
 
-    const StatisticData data = test_measure_linux_cpu->getStatisticsResults();
+    const moving_average_statistics::StatisticData data =
+      test_measure_linux_cpu->getStatisticsResults();
     ASSERT_TRUE(std::isnan(data.average));
     ASSERT_TRUE(std::isnan(data.min));
     ASSERT_TRUE(std::isnan(data.max));

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -34,7 +34,7 @@ constexpr const std::chrono::milliseconds TEST_PERIOD =
 constexpr const double CPU_ACTIVE_PERCENTAGE = 2.8002699055330633;
 }  // namespace
 
-class TestLinuxCpuMeasurementNode : public LinuxCpuMeasurementNode
+class TestLinuxCpuMeasurementNode : public system_metrics_collector::LinuxCpuMeasurementNode
 {
 public:
   TestLinuxCpuMeasurementNode(
@@ -52,14 +52,14 @@ public:
   }
 
 private:
-  ProcCpuData makeSingleMeasurement() override
+  system_metrics_collector::ProcCpuData makeSingleMeasurement() override
   {
     first = !first;
 
     if (first) {
-      return processLine(proc_sample_1);
+      return system_metrics_collector::processLine(proc_sample_1);
     } else {
-      return processLine(proc_sample_2);
+      return system_metrics_collector::processLine(proc_sample_2);
     }
   }
 
@@ -109,7 +109,7 @@ TEST_F(LinuxCpuMeasurementTestFixture, testManualMeasurement) {
 
 TEST(LinuxCpuMeasurementTest, testParseProcLine)
 {
-  auto parsed_data = processLine(proc_sample_1);
+  auto parsed_data = system_metrics_collector::processLine(proc_sample_1);
 
   ASSERT_EQ("cpu", parsed_data.cpu_label);
   ASSERT_EQ(22451232, parsed_data.times[0]);
@@ -129,8 +129,8 @@ TEST(LinuxCpuMeasurementTest, testParseProcLine)
 
 TEST(LinuxCpuMeasurementTest, testCalculateCpuActivePercentage)
 {
-  auto parsed_data1 = processLine(proc_sample_1);
-  auto parsed_data2 = processLine(proc_sample_2);
+  auto parsed_data1 = system_metrics_collector::processLine(proc_sample_1);
+  auto parsed_data2 = system_metrics_collector::processLine(proc_sample_2);
 
   auto p = computeCpuActivePercentage(parsed_data1, parsed_data2);
   ASSERT_DOUBLE_EQ(CPU_ACTIVE_PERCENTAGE, p);
@@ -138,10 +138,12 @@ TEST(LinuxCpuMeasurementTest, testCalculateCpuActivePercentage)
 
 TEST(LinuxCpuMeasurementTest, testEmptyProcCpuData)
 {
-  ProcCpuData empty;
-  ASSERT_EQ(ProcCpuData::EMPTY_LABEL, empty.cpu_label);
+  system_metrics_collector::ProcCpuData empty;
+  ASSERT_EQ(system_metrics_collector::ProcCpuData::EMPTY_LABEL, empty.cpu_label);
 
-  for (int i = 0; i < static_cast<int>(ProcCpuStates::kNumProcCpuStates); i++) {
+  for (int i = 0; i < static_cast<int>(system_metrics_collector::ProcCpuStates::kNumProcCpuStates);
+    i++)
+  {
     ASSERT_EQ(0, empty.times[i]);
   }
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -98,7 +98,7 @@ public:
   double periodicMeasurement() override
   {
     // override to avoid calling methods involved in file i/o
-    return system_metrics_collector::processLines(test_string_);
+    return system_metrics_collector::processMemInfoLines(test_string_);
   }
 
   void setTestString(std::string & test_string)
@@ -156,24 +156,24 @@ TEST_F(LinuxMemoryMeasurementTestFixture, testManualMeasurement) {
 
 TEST(LinuxMemoryMeasurementTest, testReadInvalidFile)
 {
-  const auto s = system_metrics_collector::readFile("this_will_fail.txt");
+  const auto s = system_metrics_collector::readFileToString("this_will_fail.txt");
   ASSERT_EQ("", s);
 }
 
 TEST(LinuxMemoryMeasurementTest, testProcessLines)
 {
-  auto d = system_metrics_collector::processLines(EMPTY_SAMPLE);
+  auto d = system_metrics_collector::processMemInfoLines(EMPTY_SAMPLE);
   ASSERT_TRUE(std::isnan(d));
 
-  d = system_metrics_collector::processLines(GARBAGE_SAMPLE);
+  d = system_metrics_collector::processMemInfoLines(GARBAGE_SAMPLE);
   ASSERT_TRUE(std::isnan(d));
 
-  d = system_metrics_collector::processLines(INCOMPLETE_SAMPLE);
+  d = system_metrics_collector::processMemInfoLines(INCOMPLETE_SAMPLE);
   ASSERT_TRUE(std::isnan(d));
 
-  d = system_metrics_collector::processLines(COMPLETE_SAMPLE);
+  d = system_metrics_collector::processMemInfoLines(COMPLETE_SAMPLE);
   ASSERT_DOUBLE_EQ(MEMORY_USED_PERCENTAGE, d);
 
-  d = system_metrics_collector::processLines(FULL_SAMPLE);
+  d = system_metrics_collector::processMemInfoLines(FULL_SAMPLE);
   ASSERT_DOUBLE_EQ(MEMORY_USED_PERCENTAGE, d);
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -123,7 +123,8 @@ public:
 
     ASSERT_FALSE(test_measure_linux_memory->isStarted());
 
-    const StatisticData data = test_measure_linux_memory->getStatisticsResults();
+    const moving_average_statistics::StatisticData data =
+      test_measure_linux_memory->getStatisticsResults();
     ASSERT_TRUE(std::isnan(data.average));
     ASSERT_TRUE(std::isnan(data.min));
     ASSERT_TRUE(std::isnan(data.max));
@@ -155,7 +156,7 @@ TEST_F(LinuxMemoryMeasurementTestFixture, testManualMeasurement) {
 
 TEST(LinuxMemoryMeasurementTest, testReadInvalidFile)
 {
-  auto s = readFile("this_will_fail.txt");
+  const auto s = readFile("this_will_fail.txt");
   ASSERT_EQ("", s);
 }
 

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -83,7 +83,7 @@ constexpr const auto TEST_PERIOD{std::chrono::milliseconds(50)};
 constexpr const double MEMORY_USED_PERCENTAGE = 44.148416198995363;
 }  // namespace
 
-class TestLinuxMemoryMeasurementNode : public LinuxMemoryMeasurementNode
+class TestLinuxMemoryMeasurementNode : public system_metrics_collector::LinuxMemoryMeasurementNode
 {
 public:
   TestLinuxMemoryMeasurementNode(
@@ -98,7 +98,7 @@ public:
   double periodicMeasurement() override
   {
     // override to avoid calling methods involved in file i/o
-    return processLines(test_string_);
+    return system_metrics_collector::processLines(test_string_);
   }
 
   void setTestString(std::string & test_string)
@@ -156,24 +156,24 @@ TEST_F(LinuxMemoryMeasurementTestFixture, testManualMeasurement) {
 
 TEST(LinuxMemoryMeasurementTest, testReadInvalidFile)
 {
-  const auto s = readFile("this_will_fail.txt");
+  const auto s = system_metrics_collector::readFile("this_will_fail.txt");
   ASSERT_EQ("", s);
 }
 
 TEST(LinuxMemoryMeasurementTest, testProcessLines)
 {
-  auto d = processLines(EMPTY_SAMPLE);
+  auto d = system_metrics_collector::processLines(EMPTY_SAMPLE);
   ASSERT_TRUE(std::isnan(d));
 
-  d = processLines(GARBAGE_SAMPLE);
+  d = system_metrics_collector::processLines(GARBAGE_SAMPLE);
   ASSERT_TRUE(std::isnan(d));
 
-  d = processLines(INCOMPLETE_SAMPLE);
+  d = system_metrics_collector::processLines(INCOMPLETE_SAMPLE);
   ASSERT_TRUE(std::isnan(d));
 
-  d = processLines(COMPLETE_SAMPLE);
+  d = system_metrics_collector::processLines(COMPLETE_SAMPLE);
   ASSERT_DOUBLE_EQ(MEMORY_USED_PERCENTAGE, d);
 
-  d = processLines(FULL_SAMPLE);
+  d = system_metrics_collector::processLines(FULL_SAMPLE);
   ASSERT_DOUBLE_EQ(MEMORY_USED_PERCENTAGE, d);
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -37,7 +37,7 @@ constexpr const std::chrono::milliseconds TEST_PERIOD =
 /**
  * Simple extension to test basic functionality
  */
-class TestPeriodicMeasurementNode : public PeriodicMeasurementNode
+class TestPeriodicMeasurementNode : public ::system_metrics_collector::PeriodicMeasurementNode
 {
 public:
   TestPeriodicMeasurementNode(

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -80,7 +80,8 @@ public:
 
     ASSERT_FALSE(test_periodic_measurer->isStarted());
 
-    const StatisticData data = test_periodic_measurer->getStatisticsResults();
+    const moving_average_statistics::StatisticData data =
+      test_periodic_measurer->getStatisticsResults();
     ASSERT_TRUE(std::isnan(data.average));
     ASSERT_TRUE(std::isnan(data.min));
     ASSERT_TRUE(std::isnan(data.max));
@@ -125,7 +126,8 @@ TEST_F(PeriodicMeasurementTestFixure, test_start_and_stop) {
   ex.add_node(test_periodic_measurer);
   ex.spin_until_future_complete(dummy_future, TEST_LENGTH);
 
-  StatisticData data = test_periodic_measurer->getStatisticsResults();
+  const moving_average_statistics::StatisticData data =
+    test_periodic_measurer->getStatisticsResults();
   ASSERT_EQ(3, data.average);
   ASSERT_EQ(1, data.min);
   ASSERT_EQ(TEST_LENGTH.count() / TEST_PERIOD.count(), data.max);


### PR DESCRIPTION
Add namespaces to the system metrics collector classes, per the folder structure, and rename methods that were too generic and could be confusing / overloaded.