### PR TITLE
Fix bug in computeCpuActivePercentage()

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -72,7 +72,7 @@ double computeCpuActivePercentage(
 
   const double active_time = measurement2.getActiveTime() - measurement1.getActiveTime();
   const double total_time = (measurement2.getIdleTime() + measurement2.getActiveTime()) -
-    (measurement1.getIdleTime() + measurement2.getActiveTime());
+    (measurement1.getIdleTime() + measurement1.getActiveTime());
 
   return 100.0 * active_time / total_time;
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -31,7 +31,7 @@ constexpr const char proc_sample_2[] =
   "cpu  22451360 118653 7348080 934949227 5378120 0 419117 0 0 0\n";
 constexpr const std::chrono::milliseconds TEST_PERIOD =
   std::chrono::milliseconds(50);
-constexpr const double CPU_ACTIVE_PERCENTAGE = 2.8002699055330633;
+constexpr const double CPU_ACTIVE_PERCENTAGE = 2.7239908106334099;
 }  // namespace
 
 class TestLinuxCpuMeasurementNode : public system_metrics_collector::LinuxCpuMeasurementNode


### PR DESCRIPTION
There is a calculation error `computeCpuActivePercentage()` for the total CPU time that has elapsed between the previous and current measurements.