### PR TITLE
Add MetricsMessagePublisher interface and implementation

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -61,6 +61,11 @@ if(BUILD_TESTING)
   target_link_libraries(test_collector system_metrics_collector)
   ament_target_dependencies(test_collector rclcpp)
 
+  ament_add_gtest(test_metrics_message_publisher
+    test/system_metrics_collector/test_metrics_message_publisher.cpp)
+  target_link_libraries(test_metrics_message_publisher system_metrics_collector)
+  ament_target_dependencies(test_metrics_message_publisher metrics_statistics_msgs rclcpp)
+
   ament_add_gtest(test_linux_cpu_measurement_node
           test/system_metrics_collector/test_linux_cpu_measurement.cpp)
   target_link_libraries(test_linux_cpu_measurement_node system_metrics_collector)

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -28,21 +28,22 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rcutils REQUIRED)
 find_package(metrics_statistics_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcpputils REQUIRED)
+find_package(rcutils REQUIRED)
 
 add_library(system_metrics_collector SHARED
+  src/moving_average_statistics/moving_average.cpp
+  src/moving_average_statistics/types.hpp
+  src/system_metrics_collector/metrics_message_publisher.cpp
   src/system_metrics_collector/collector.cpp
   src/system_metrics_collector/linux_cpu_measurement_node.cpp
   src/system_metrics_collector/linux_memory_measurement_node.cpp
   src/system_metrics_collector/periodic_measurement_node.cpp
   src/system_metrics_collector/proc_cpu_data.cpp
-  src/moving_average_statistics/moving_average.cpp
-  src/moving_average_statistics/types.hpp
 )
-
-ament_target_dependencies(system_metrics_collector rclcpp rcpputils)
+ament_target_dependencies(system_metrics_collector rclcpp rcutils rcpputils metrics_statistics_msgs)
 ament_export_libraries(system_metrics_collector)
 
 add_executable(main src/system_metrics_collector/main.cpp)
@@ -63,22 +64,22 @@ if(BUILD_TESTING)
   ament_add_gtest(test_linux_cpu_measurement_node
           test/system_metrics_collector/test_linux_cpu_measurement.cpp)
   target_link_libraries(test_linux_cpu_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_linux_cpu_measurement_node rclcpp)
+  ament_target_dependencies(test_linux_cpu_measurement_node rclcpp metrics_statistics_msgs)
 
   ament_add_gtest(test_linux_memory_measurement_node
           test/system_metrics_collector/test_linux_memory_measurement.cpp)
   target_link_libraries(test_linux_memory_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_linux_memory_measurement_node rclcpp)
+  ament_target_dependencies(test_linux_memory_measurement_node rclcpp metrics_statistics_msgs)
 
   ament_add_gtest(test_moving_average_statistics
-          test/moving_average_statistics/test_moving_average_statistics.cpp)
+    test/moving_average_statistics/test_moving_average_statistics.cpp)
   target_link_libraries(test_moving_average_statistics system_metrics_collector)
   ament_target_dependencies(test_moving_average_statistics rclcpp)
 
   ament_add_gtest(test_periodic_measurement_node
     test/system_metrics_collector/test_periodic_measurement_node.cpp)
   target_link_libraries(test_periodic_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_periodic_measurement_node rclcpp)
+  ament_target_dependencies(test_periodic_measurement_node rclcpp metrics_statistics_msgs)
 
   install(TARGETS
     test_moving_average_statistics

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -43,7 +43,7 @@ add_library(system_metrics_collector SHARED
   src/system_metrics_collector/periodic_measurement_node.cpp
   src/system_metrics_collector/proc_cpu_data.cpp
 )
-ament_target_dependencies(system_metrics_collector rclcpp rcutils rcpputils metrics_statistics_msgs)
+ament_target_dependencies(system_metrics_collector metrics_statistics_msgs rclcpp rcpputils rcutils)
 ament_export_libraries(system_metrics_collector)
 
 add_executable(main src/system_metrics_collector/main.cpp)
@@ -64,22 +64,22 @@ if(BUILD_TESTING)
   ament_add_gtest(test_linux_cpu_measurement_node
           test/system_metrics_collector/test_linux_cpu_measurement.cpp)
   target_link_libraries(test_linux_cpu_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_linux_cpu_measurement_node rclcpp metrics_statistics_msgs)
+  ament_target_dependencies(test_linux_cpu_measurement_node metrics_statistics_msgs rclcpp)
 
   ament_add_gtest(test_linux_memory_measurement_node
           test/system_metrics_collector/test_linux_memory_measurement.cpp)
   target_link_libraries(test_linux_memory_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_linux_memory_measurement_node rclcpp metrics_statistics_msgs)
+  ament_target_dependencies(test_linux_memory_measurement_node metrics_statistics_msgs rclcpp)
 
   ament_add_gtest(test_moving_average_statistics
-    test/moving_average_statistics/test_moving_average_statistics.cpp)
+          test/moving_average_statistics/test_moving_average_statistics.cpp)
   target_link_libraries(test_moving_average_statistics system_metrics_collector)
   ament_target_dependencies(test_moving_average_statistics rclcpp)
 
   ament_add_gtest(test_periodic_measurement_node
     test/system_metrics_collector/test_periodic_measurement_node.cpp)
   target_link_libraries(test_periodic_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_periodic_measurement_node rclcpp metrics_statistics_msgs)
+  ament_target_dependencies(test_periodic_measurement_node metrics_statistics_msgs rclcpp)
 
   install(TARGETS
     test_moving_average_statistics

--- a/system_metrics_collector/src/moving_average_statistics/types.hpp
+++ b/system_metrics_collector/src/moving_average_statistics/types.hpp
@@ -15,11 +15,26 @@
 #ifndef MOVING_AVERAGE_STATISTICS__TYPES_HPP_
 #define MOVING_AVERAGE_STATISTICS__TYPES_HPP_
 
+#include <array>
+#include <cmath>
 #include <sstream>
 #include <string>
 
+#include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
+
 namespace moving_average_statistics
 {
+
+/**
+ *  Enumeration of the various StatisticDataTypes
+ */
+constexpr const std::array<uint8_t, 5> STATISTICS_DATA_TYPES = {
+  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE,
+  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_MAXIMUM,
+  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_MINIMUM,
+  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT,
+  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_STDDEV
+};
 
 /**
  *  A container for statistics data results for a set of recorded observations.

--- a/system_metrics_collector/src/moving_average_statistics/types.hpp
+++ b/system_metrics_collector/src/moving_average_statistics/types.hpp
@@ -15,26 +15,12 @@
 #ifndef MOVING_AVERAGE_STATISTICS__TYPES_HPP_
 #define MOVING_AVERAGE_STATISTICS__TYPES_HPP_
 
-#include <array>
 #include <cmath>
 #include <sstream>
 #include <string>
 
-#include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
-
 namespace moving_average_statistics
 {
-
-/**
- *  Enumeration of the various StatisticDataTypes
- */
-constexpr const std::array<uint8_t, 5> STATISTICS_DATA_TYPES = {
-  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE,
-  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_MAXIMUM,
-  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_MINIMUM,
-  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT,
-  metrics_statistics_msgs::msg::StatisticDataType::STATISTICS_DATA_TYPE_STDDEV
-};
 
 /**
  *  A container for statistics data results for a set of recorded observations.

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -117,4 +117,11 @@ system_metrics_collector::ProcCpuData LinuxCpuMeasurementNode::makeSingleMeasure
   }
 }
 
+void LinuxCpuMeasurementNode::publishStatisticMessage()
+{
+  auto msg = generateStatisticMessage(get_name(), "cpu_usage", window_start_,
+      now(), getStatisticsResults());
+  publisher_->publish(msg);
+}
+
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -25,6 +25,7 @@
 
 namespace
 {
+constexpr const char MEASUREMENT_TYPE[] = "cpu_usage";
 constexpr const char PROC_STAT_FILE[] = "/proc/stat";
 constexpr const char CPU_LABEL[] = "cpu";
 }  // namespace
@@ -119,7 +120,7 @@ system_metrics_collector::ProcCpuData LinuxCpuMeasurementNode::makeSingleMeasure
 
 void LinuxCpuMeasurementNode::publishStatisticMessage()
 {
-  auto msg = generateStatisticMessage(get_name(), "cpu_usage", window_start_,
+  auto msg = generateStatisticMessage(get_name(), MEASUREMENT_TYPE, window_start_,
       now(), getStatisticsResults());
   publisher_->publish(msg);
 }

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -25,7 +25,7 @@
 
 namespace
 {
-constexpr const char MEASUREMENT_TYPE[] = "cpu_usage";
+constexpr const char MEASUREMENT_TYPE[] = "system_cpu_usage";
 constexpr const char PROC_STAT_FILE[] = "/proc/stat";
 constexpr const char CPU_LABEL[] = "cpu";
 }  // namespace

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -85,6 +85,11 @@ private:
   virtual system_metrics_collector::ProcCpuData makeSingleMeasurement();
 
   /**
+   * Publish the statistics derived from the collected measurements
+   */
+  void publishStatisticMessage() override;
+
+  /**
    * The cached measurement used in order to perform the CPU active
    * percentage.
    */

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -124,4 +124,11 @@ double LinuxMemoryMeasurementNode::periodicMeasurement()
   return processMemInfoLines(read_string);
 }
 
+void LinuxMemoryMeasurementNode::publishStatisticMessage()
+{
+  auto msg = generateStatisticMessage(get_name(), "memory_usage", window_start_,
+      now(), getStatisticsResults());
+  publisher_->publish(msg);
+}
+
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -26,7 +26,7 @@
 
 namespace
 {
-constexpr const char MEASUREMENT_TYPE[] = "memory_usage";
+constexpr const char MEASUREMENT_TYPE[] = "system_memory_usage";
 constexpr const char PROC_STAT_FILE[] = "/proc/meminfo";
 constexpr const char MEM_TOTAL[] = "MemTotal:";
 constexpr const char MEM_AVAILABLE[] = "MemAvailable:";

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -26,6 +26,7 @@
 
 namespace
 {
+constexpr const char MEASUREMENT_TYPE[] = "memory_usage";
 constexpr const char PROC_STAT_FILE[] = "/proc/meminfo";
 constexpr const char MEM_TOTAL[] = "MemTotal:";
 constexpr const char MEM_AVAILABLE[] = "MemAvailable:";
@@ -126,7 +127,7 @@ double LinuxMemoryMeasurementNode::periodicMeasurement()
 
 void LinuxMemoryMeasurementNode::publishStatisticMessage()
 {
-  auto msg = generateStatisticMessage(get_name(), "memory_usage", window_start_,
+  auto msg = generateStatisticMessage(get_name(), MEASUREMENT_TYPE, window_start_,
       now(), getStatisticsResults());
   publisher_->publish(msg);
 }

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -79,6 +79,11 @@ protected:
    * @return percentage of RAM used
    */
   double periodicMeasurement() override;
+
+  /**
+   * Publish the statistics derived from the collected measurements
+   */
+  void publishStatisticMessage() override;
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -25,6 +25,8 @@
 #include "../../src/system_metrics_collector/linux_cpu_measurement_node.hpp"
 #include "../../src/system_metrics_collector/linux_memory_measurement_node.hpp"
 
+static constexpr const char STATISTICS_TOPIC_NAME[] = "system_metrics";
+
 /**
  * This is current a "test" main in order to manually test the measurement nodes.
  *
@@ -39,13 +41,13 @@ int main(int argc, char ** argv)
   auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
     "linuxCpuCollector",
     std::chrono::milliseconds(1000),
-    "not_publishing_yet",
+    STATISTICS_TOPIC_NAME,
     std::chrono::milliseconds(1000 * 60));
 
   auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector",
     std::chrono::milliseconds(1000),
-    "not_publishing_yet",
+    STATISTICS_TOPIC_NAME,
     std::chrono::milliseconds(1000 * 60));
 
   rclcpp::executors::MultiThreadedExecutor ex;
@@ -58,7 +60,6 @@ int main(int argc, char ** argv)
   }
 
   r = rcutils_logging_set_logger_level(mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
   if (r != 0) {
     RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the memory node");
   }

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -25,7 +25,10 @@
 #include "../../src/system_metrics_collector/linux_cpu_measurement_node.hpp"
 #include "../../src/system_metrics_collector/linux_memory_measurement_node.hpp"
 
-static constexpr const char STATISTICS_TOPIC_NAME[] = "system_metrics";
+namespace
+{
+constexpr const char STATISTICS_TOPIC_NAME[] = "system_metrics";
+}
 
 /**
  * This is current a "test" main in order to manually test the measurement nodes.

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
@@ -1,0 +1,61 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "metrics_message_publisher.hpp"
+
+#include <string>
+#include <utility>
+
+#include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
+
+using metrics_statistics_msgs::msg::MetricsMessage;
+using metrics_statistics_msgs::msg::StatisticDataPoint;
+using metrics_statistics_msgs::msg::StatisticDataType;
+
+namespace system_metrics_collector
+{
+
+/* static */
+constexpr const std::chrono::milliseconds MetricsMessagePublisher::INVALID_PUBLISH_WINDOW;
+
+MetricsMessage MetricsMessagePublisher::generateStatisticMessage(
+  std::string node_name,
+  std::string source_name,
+  builtin_interfaces::msg::Time window_start,
+  builtin_interfaces::msg::Time window_stop,
+  const moving_average_statistics::StatisticData & data)
+{
+  MetricsMessage msg;
+
+  msg.measurement_source_name = std::move(node_name);
+  msg.metrics_source = std::move(source_name);
+  msg.window_start = std::move(window_start);
+  msg.window_stop = std::move(window_stop);
+
+  msg.statistics.resize(moving_average_statistics::STATISTICS_DATA_TYPES.size());
+  msg.statistics[0].data_type = StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE;
+  msg.statistics[0].data = data.average;
+  msg.statistics[1].data_type = StatisticDataType::STATISTICS_DATA_TYPE_MAXIMUM;
+  msg.statistics[1].data = data.max;
+  msg.statistics[2].data_type = StatisticDataType::STATISTICS_DATA_TYPE_MINIMUM;
+  msg.statistics[2].data = data.min;
+  msg.statistics[3].data_type = StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT;
+  msg.statistics[3].data = data.sample_count;
+  msg.statistics[4].data_type = StatisticDataType::STATISTICS_DATA_TYPE_STDDEV;
+  msg.statistics[4].data = data.standard_deviation;
+
+  return msg;
+}
+
+}  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
@@ -26,9 +26,6 @@ using metrics_statistics_msgs::msg::StatisticDataType;
 namespace system_metrics_collector
 {
 
-/* static */
-constexpr const std::chrono::milliseconds MetricsMessagePublisher::INVALID_PUBLISH_WINDOW;
-
 MetricsMessage MetricsMessagePublisher::generateStatisticMessage(
   const std::string & node_name,
   const std::string & source_name,

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
@@ -29,8 +29,8 @@ namespace system_metrics_collector
 MetricsMessage MetricsMessagePublisher::generateStatisticMessage(
   const std::string & node_name,
   const std::string & source_name,
-  const builtin_interfaces::msg::Time & window_start,
-  const builtin_interfaces::msg::Time & window_stop,
+  const builtin_interfaces::msg::Time window_start,
+  const builtin_interfaces::msg::Time window_stop,
   const moving_average_statistics::StatisticData & data)
 {
   MetricsMessage msg;

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
@@ -30,30 +30,40 @@ namespace system_metrics_collector
 constexpr const std::chrono::milliseconds MetricsMessagePublisher::INVALID_PUBLISH_WINDOW;
 
 MetricsMessage MetricsMessagePublisher::generateStatisticMessage(
-  std::string node_name,
-  std::string source_name,
-  builtin_interfaces::msg::Time window_start,
-  builtin_interfaces::msg::Time window_stop,
+  const std::string & node_name,
+  const std::string & source_name,
+  const builtin_interfaces::msg::Time & window_start,
+  const builtin_interfaces::msg::Time & window_stop,
   const moving_average_statistics::StatisticData & data)
 {
   MetricsMessage msg;
 
-  msg.measurement_source_name = std::move(node_name);
-  msg.metrics_source = std::move(source_name);
-  msg.window_start = std::move(window_start);
-  msg.window_stop = std::move(window_stop);
+  msg.measurement_source_name = node_name;
+  msg.metrics_source = source_name;
+  msg.window_start = window_start;
+  msg.window_stop = window_stop;
 
-  msg.statistics.resize(moving_average_statistics::STATISTICS_DATA_TYPES.size());
-  msg.statistics[0].data_type = StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE;
-  msg.statistics[0].data = data.average;
-  msg.statistics[1].data_type = StatisticDataType::STATISTICS_DATA_TYPE_MAXIMUM;
-  msg.statistics[1].data = data.max;
-  msg.statistics[2].data_type = StatisticDataType::STATISTICS_DATA_TYPE_MINIMUM;
-  msg.statistics[2].data = data.min;
-  msg.statistics[3].data_type = StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT;
-  msg.statistics[3].data = data.sample_count;
-  msg.statistics[4].data_type = StatisticDataType::STATISTICS_DATA_TYPE_STDDEV;
-  msg.statistics[4].data = data.standard_deviation;
+  msg.statistics.reserve(5);
+
+  msg.statistics.emplace_back();
+  msg.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE;
+  msg.statistics.back().data = data.average;
+
+  msg.statistics.emplace_back();
+  msg.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_MAXIMUM;
+  msg.statistics.back().data = data.max;
+
+  msg.statistics.emplace_back();
+  msg.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_MINIMUM;
+  msg.statistics.back().data = data.min;
+
+  msg.statistics.emplace_back();
+  msg.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT;
+  msg.statistics.back().data = data.sample_count;
+
+  msg.statistics.emplace_back();
+  msg.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_STDDEV;
+  msg.statistics.back().data = data.standard_deviation;
 
   return msg;
 }

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -32,9 +32,6 @@ namespace system_metrics_collector
 class MetricsMessagePublisher
 {
 public:
-  static constexpr const std::chrono::milliseconds INVALID_PUBLISH_WINDOW =
-    std::chrono::milliseconds(0);
-
   /**
    * Return a valid MetricsMessage ready to be published to a ROS topic
    *

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -1,0 +1,65 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SYSTEM_METRICS_COLLECTOR__METRICS_MESSAGE_PUBLISHER_HPP_
+#define SYSTEM_METRICS_COLLECTOR__METRICS_MESSAGE_PUBLISHER_HPP_
+
+#include <chrono>
+#include <string>
+
+#include "builtin_interfaces/msg/time.hpp"
+#include "metrics_statistics_msgs/msg/metrics_message.hpp"
+
+#include "../moving_average_statistics/types.hpp"
+
+namespace system_metrics_collector
+{
+
+/**
+ * Simple class to facilitate publishing messages containing statistics data
+ */
+class MetricsMessagePublisher
+{
+public:
+  static constexpr const std::chrono::milliseconds INVALID_PUBLISH_WINDOW =
+    std::chrono::milliseconds(0);
+
+  /**
+   * Return a valid MetricsMessage ready to be published to a ROS topic
+   *
+   * @param node_name the name of the node that the data originates from
+   * @param metric_name the name of the metric ("cpu_usage", "memory_usage", etc.)
+   * @param window_start measurement window start time
+   * @param window_stop measurement window end time
+   * @param data statistics derived from the measurements made in the window
+   * @return a MetricsMessage containing the statistics in the data parameter
+   */
+  static metrics_statistics_msgs::msg::MetricsMessage generateStatisticMessage(
+    std::string node_name,
+    std::string metric_name,
+    builtin_interfaces::msg::Time window_start,
+    builtin_interfaces::msg::Time window_stop,
+    const moving_average_statistics::StatisticData & data
+  );
+
+  /**
+   * Called via a ROS2 timer per the publish_period_. This publishes the statistics derived from
+   * the collected measurements
+   */
+  virtual void publishStatisticMessage() = 0;
+};
+
+}  // namespace system_metrics_collector
+
+#endif  // SYSTEM_METRICS_COLLECTOR__METRICS_MESSAGE_PUBLISHER_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -45,8 +45,8 @@ public:
   static metrics_statistics_msgs::msg::MetricsMessage generateStatisticMessage(
     const std::string & node_name,
     const std::string & metric_name,
-    const builtin_interfaces::msg::Time & window_start,
-    const builtin_interfaces::msg::Time & window_stop,
+    const builtin_interfaces::msg::Time window_start,
+    const builtin_interfaces::msg::Time window_stop,
     const moving_average_statistics::StatisticData & data
   );
 

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -46,16 +46,16 @@ public:
    * @return a MetricsMessage containing the statistics in the data parameter
    */
   static metrics_statistics_msgs::msg::MetricsMessage generateStatisticMessage(
-    std::string node_name,
-    std::string metric_name,
-    builtin_interfaces::msg::Time window_start,
-    builtin_interfaces::msg::Time window_stop,
+    const std::string & node_name,
+    const std::string & metric_name,
+    const builtin_interfaces::msg::Time & window_start,
+    const builtin_interfaces::msg::Time & window_stop,
     const moving_average_statistics::StatisticData & data
   );
 
   /**
-   * Called via a ROS2 timer per the publish_period_. This publishes the statistics derived from
-   * the collected measurements
+   * Publish the statistics derived from the collected measurements (this is to be called via a
+   * ROS2 timer per the publish_period)
    */
   virtual void publishStatisticMessage() = 0;
 };

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -24,9 +24,6 @@
 namespace system_metrics_collector
 {
 
-/* static */ constexpr const std::chrono::milliseconds PeriodicMeasurementNode::
-INVALID_PUBLISH_WINDOW;
-
 PeriodicMeasurementNode::PeriodicMeasurementNode(
   const std::string & name,
   const std::chrono::milliseconds measurement_period,
@@ -80,6 +77,10 @@ bool PeriodicMeasurementNode::setupStop()
   if (measurement_timer_) {
     measurement_timer_->cancel();
     measurement_timer_.reset();
+  }
+  if (publish_timer_) {
+    publish_timer_->cancel();
+    publish_timer_.reset();
   }
   return true;
 }

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -45,43 +45,23 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
 
 bool PeriodicMeasurementNode::setupStart()
 {
-  if (!measurement_timer_) {
-    RCLCPP_DEBUG(this->get_logger(), "setupStart: creating measurement_timer_");
+  assert(measurement_timer_ == nullptr);
 
-    measurement_timer_ = this->create_wall_timer(
-      measurement_period_,
-      std::bind(&PeriodicMeasurementNode::performPeriodicMeasurement, this));
-
-  } else {
-    RCLCPP_WARN(this->get_logger(), "setupStart: measurement_timer_ already exists!");
-  }
-
-  if (!publish_timer_ && publish_period_ != INVALID_PUBLISH_WINDOW) {
-    RCLCPP_DEBUG(this->get_logger(), "setupStart: creating publish_timer_");
-
-    publish_timer_ = this->create_wall_timer(
-      publish_period_,
-      std::bind(&Collector::clearCurrentMeasurements, this));  // todo fixme, bind to publish method
-
-  } else {
-    if (publish_timer_) {
-      RCLCPP_WARN(this->get_logger(), "setupStart: publish_timer_ already exists!");
-    }
-  }
+  RCLCPP_DEBUG(this->get_logger(), "setupStart: creating measurement_timer_");
+  measurement_timer_ = this->create_wall_timer(
+    measurement_period_,
+    std::bind(&PeriodicMeasurementNode::performPeriodicMeasurement, this));
 
   return true;
 }
 
 bool PeriodicMeasurementNode::setupStop()
 {
-  if (measurement_timer_) {
-    measurement_timer_->cancel();
-    measurement_timer_.reset();
-  }
-  if (publish_timer_) {
-    publish_timer_->cancel();
-    publish_timer_.reset();
-  }
+  assert(measurement_timer_ != nullptr);
+
+  measurement_timer_->cancel();
+  measurement_timer_.reset();
+
   return true;
 }
 
@@ -92,7 +72,7 @@ std::string PeriodicMeasurementNode::getStatusString() const
     ", measurement_period=" << std::to_string(measurement_period_.count()) << "ms" <<
     ", publishing_topic=" << publishing_topic_ <<
     ", publish_period=" <<
-  (publish_period_ != INVALID_PUBLISH_WINDOW ?
+  (publish_period_ > std::chrono::milliseconds(0) ?
   std::to_string(publish_period_.count()) + "ms" : "None") <<
     ", clear_measurements_on_publish_=" << clear_measurements_on_publish_ <<
     ", " << Collector::getStatusString();

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -19,8 +19,8 @@
 #include <chrono>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 #include "collector.hpp"
 #include "metrics_message_publisher.hpp"
@@ -61,6 +61,14 @@ public:
    * @return a string detailing the current status
    */
   std::string getStatusString() const override;
+
+protected:
+  /**
+   * Track the starting time of the statistics
+   */
+  rclcpp::Time window_start_;
+
+  rclcpp::Publisher<metrics_statistics_msgs::msg::MetricsMessage>::SharedPtr publisher_;
 
 private:
   /**
@@ -110,14 +118,6 @@ private:
 
   rclcpp::TimerBase::SharedPtr measurement_timer_;
   rclcpp::TimerBase::SharedPtr publish_timer_;
-
-protected:
-  /**
-   * Track the starting time of the statistics
-   */
-  rclcpp::Time window_start_;
-
-  rclcpp::Publisher<metrics_statistics_msgs::msg::MetricsMessage>::SharedPtr publisher_;
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -19,9 +19,12 @@
 #include <chrono>
 #include <string>
 
-#include "collector.hpp"
-
 #include "rclcpp/rclcpp.hpp"
+#include "metrics_statistics_msgs/msg/metrics_message.hpp"
+
+#include "collector.hpp"
+#include "metrics_message_publisher.hpp"
+
 
 namespace system_metrics_collector
 {
@@ -29,12 +32,10 @@ namespace system_metrics_collector
 /**
  * Class which makes periodic measurements, using a ROS2 timer.
  */
-class PeriodicMeasurementNode : public system_metrics_collector::Collector, public rclcpp::Node
+class PeriodicMeasurementNode : public system_metrics_collector::Collector,
+  public system_metrics_collector::MetricsMessagePublisher, public rclcpp::Node
 {
 public:
-  static constexpr const std::chrono::milliseconds INVALID_PUBLISH_WINDOW =
-    std::chrono::milliseconds(0);
-
   /**
    * Construct a PeriodicMeasurementNode.
    *
@@ -90,9 +91,6 @@ private:
    */
   bool setupStop() override;
 
-  // todo implement on publish timer callback, check if we need to clear the window
-  // todo this is part of the publishing interface
-
   /**
    * Topic used for publishing
    */
@@ -109,8 +107,17 @@ private:
    * If true, then measurements are cleared after publishing data
    */
   const bool clear_measurements_on_publish_;
+
   rclcpp::TimerBase::SharedPtr measurement_timer_;
   rclcpp::TimerBase::SharedPtr publish_timer_;
+
+protected:
+  /**
+   * The tracking of the starting time of the statistics
+   */
+  rclcpp::Time window_start_;
+
+  rclcpp::Publisher<metrics_statistics_msgs::msg::MetricsMessage>::SharedPtr publisher_;
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -99,6 +99,8 @@ private:
    */
   bool setupStop() override;
 
+  // todo implement on publish timer callback, check if we need to clear the window
+
   /**
    * Topic used for publishing
    */

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -113,7 +113,7 @@ private:
 
 protected:
   /**
-   * The tracking of the starting time of the statistics
+   * Track the starting time of the statistics
    */
   rclcpp::Time window_start_;
 

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -26,7 +26,7 @@
 namespace
 {
 constexpr const std::chrono::milliseconds INVALID_PUBLISH_WINDOW =
-    std::chrono::milliseconds(0);
+  std::chrono::milliseconds(0);
 constexpr const char proc_sample_1[] =
   "cpu  22451232 118653 7348045 934943300 5378119 0 419114 0 0 0\n";
 constexpr const char proc_sample_2[] =

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -25,6 +25,8 @@
 
 namespace
 {
+constexpr const std::chrono::milliseconds INVALID_PUBLISH_WINDOW =
+    std::chrono::milliseconds(0);
 constexpr const char proc_sample_1[] =
   "cpu  22451232 118653 7348045 934943300 5378119 0 419114 0 0 0\n";
 constexpr const char proc_sample_2[] =
@@ -32,6 +34,7 @@ constexpr const char proc_sample_2[] =
 constexpr const std::chrono::milliseconds TEST_PERIOD =
   std::chrono::milliseconds(50);
 constexpr const double CPU_ACTIVE_PERCENTAGE = 2.7239908106334099;
+
 }  // namespace
 
 class TestLinuxCpuMeasurementNode : public system_metrics_collector::LinuxCpuMeasurementNode

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -34,7 +34,6 @@ constexpr const char proc_sample_2[] =
 constexpr const std::chrono::milliseconds TEST_PERIOD =
   std::chrono::milliseconds(50);
 constexpr const double CPU_ACTIVE_PERCENTAGE = 2.7239908106334099;
-
 }  // namespace
 
 class TestLinuxCpuMeasurementNode : public system_metrics_collector::LinuxCpuMeasurementNode

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -24,6 +24,8 @@
 
 namespace
 {
+constexpr const std::chrono::milliseconds INVALID_PUBLISH_WINDOW =
+  std::chrono::milliseconds(0);
 constexpr const char EMPTY_SAMPLE[] = "";
 constexpr const char GARBAGE_SAMPLE[] = "this is garbage\n";
 constexpr const char INCOMPLETE_SAMPLE[] = "MemTotal:       16302048 kB\n"

--- a/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
@@ -1,0 +1,86 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <random>
+
+#include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "../../src/system_metrics_collector/metrics_message_publisher.hpp"
+
+using metrics_statistics_msgs::msg::MetricsMessage;
+using metrics_statistics_msgs::msg::StatisticDataPoint;
+using metrics_statistics_msgs::msg::StatisticDataType;
+using moving_average_statistics::StatisticData;
+using system_metrics_collector::MetricsMessagePublisher;
+
+
+namespace
+{
+constexpr const char TEST_NODE_NAME[] = "test_publisher";
+constexpr const char TEST_MEASUREMENT_TYPE[] = "test_measurement";
+}  // namespace
+
+TEST(MetricsMessagePublisherTest, test_generate_message) {
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>(TEST_NODE_NAME);
+  rclcpp::Time time1 = node->now();
+  rclcpp::Time time2 = node->now();
+
+  std::default_random_engine gen;
+  std::uniform_real_distribution<decltype(StatisticDataPoint::data)> dist(0.0, 100.0);
+  StatisticData data;
+  data.average = dist(gen);
+  data.min = dist(gen);
+  data.max = dist(gen);
+  data.standard_deviation = dist(gen);
+  data.sample_count = dist(gen);
+
+  MetricsMessage msg = MetricsMessagePublisher::generateStatisticMessage(
+    TEST_NODE_NAME, TEST_MEASUREMENT_TYPE, time1, time2, data);
+
+  EXPECT_EQ(TEST_NODE_NAME, msg.measurement_source_name);
+  EXPECT_EQ(TEST_MEASUREMENT_TYPE, msg.metrics_source);
+  EXPECT_EQ(time1, msg.window_start);
+  EXPECT_EQ(time2, msg.window_stop);
+
+  for (const StatisticDataPoint & stat : msg.statistics) {
+    switch (stat.data_type) {
+      case StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE:
+        EXPECT_FLOAT_EQ(data.average, stat.data);
+        break;
+      case StatisticDataType::STATISTICS_DATA_TYPE_MAXIMUM:
+        EXPECT_FLOAT_EQ(data.max, stat.data);
+        break;
+      case StatisticDataType::STATISTICS_DATA_TYPE_MINIMUM:
+        EXPECT_FLOAT_EQ(data.min, stat.data);
+        break;
+      case StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT:
+        EXPECT_EQ(data.sample_count, static_cast<decltype(StatisticData::sample_count)>(stat.data));
+        break;
+      case StatisticDataType::STATISTICS_DATA_TYPE_STDDEV:
+        EXPECT_FLOAT_EQ(data.standard_deviation, stat.data);
+        break;
+      default:
+        ADD_FAILURE() << "Unexpected statistic data type";
+        break;
+    }
+  }
+
+  node.reset();
+  rclcpp::shutdown();
+}

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -28,6 +28,8 @@
 
 namespace
 {
+constexpr const std::chrono::milliseconds INVALID_PUBLISH_WINDOW =
+  std::chrono::milliseconds(0);
 constexpr const std::chrono::milliseconds TEST_LENGTH =
   std::chrono::milliseconds(250);
 constexpr const std::chrono::milliseconds TEST_PERIOD =
@@ -80,7 +82,7 @@ public:
       "test_periodic_node",
       TEST_PERIOD,
       "test_topic",
-      ::system_metrics_collector::MetricsMessagePublisher::INVALID_PUBLISH_WINDOW);
+      INVALID_PUBLISH_WINDOW);
 
     ASSERT_FALSE(test_periodic_measurer->isStarted());
 

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -61,6 +61,8 @@ private:
     return static_cast<double>(sum.load());
   }
 
+  void publishStatisticMessage() {}
+
   std::atomic<int> sum{0};
 };
 
@@ -78,7 +80,7 @@ public:
       "test_periodic_node",
       TEST_PERIOD,
       "test_topic",
-      ::system_metrics_collector::PeriodicMeasurementNode::INVALID_PUBLISH_WINDOW);
+      ::system_metrics_collector::MetricsMessagePublisher::INVALID_PUBLISH_WINDOW);
 
     ASSERT_FALSE(test_periodic_measurer->isStarted());
 

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -61,7 +61,7 @@ private:
     return static_cast<double>(sum.load());
   }
 
-  void publishStatisticMessage() {}
+  void publishStatisticMessage() override {}
 
   std::atomic<int> sum{0};
 };


### PR DESCRIPTION
Adding the interface for `MetricsMessagePublisher` as well as some implementation of its helper functions.

The `PeriodicMeasurementNode` has been plugged in into this interface, but publishing has not been activated or made functional.