### PR TITLE
Move publish message creation to the super class

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -116,11 +116,9 @@ system_metrics_collector::ProcCpuData LinuxCpuMeasurementNode::makeSingleMeasure
   }
 }
 
-void LinuxCpuMeasurementNode::publishStatisticMessage()
+std::string LinuxCpuMeasurementNode::getMetricName()
 {
-  auto msg = generateStatisticMessage(get_name(), MEASUREMENT_TYPE, window_start_,
-      now(), getStatisticsResults());
-  publisher_->publish(msg);
+  return MEASUREMENT_TYPE;
 }
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -116,7 +116,7 @@ system_metrics_collector::ProcCpuData LinuxCpuMeasurementNode::makeSingleMeasure
   }
 }
 
-std::string LinuxCpuMeasurementNode::getMetricName()
+std::string LinuxCpuMeasurementNode::getMetricName() const
 {
   return MEASUREMENT_TYPE;
 }

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -88,7 +88,7 @@ private:
    * Return the name to use for this metric
    * @return a string of the name for this measured metric
    */
-  std::string getMetricName() override;
+  std::string getMetricName() const override;
 
   /**
    * The cached measurement used in order to perform the CPU active

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -85,9 +85,10 @@ private:
   virtual system_metrics_collector::ProcCpuData makeSingleMeasurement();
 
   /**
-   * Publish the statistics derived from the collected measurements
+   * Return the name to use for this metric
+   * @return a string of the name for this measured metric
    */
-  void publishStatisticMessage() override;
+  std::string getMetricName() override;
 
   /**
    * The cached measurement used in order to perform the CPU active

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -27,7 +27,7 @@
 
 namespace
 {
-constexpr const char MEASUREMENT_TYPE[] = "system_memory_usage";
+constexpr const char MEASUREMENT_TYPE[] = "system_memory_percent_used";
 constexpr const char PROC_STAT_FILE[] = "/proc/meminfo";
 }  // namespace
 
@@ -53,11 +53,10 @@ double LinuxMemoryMeasurementNode::periodicMeasurement()
   return processMemInfoLines(read_string);
 }
 
-void LinuxMemoryMeasurementNode::publishStatisticMessage()
+std::string LinuxMemoryMeasurementNode::getMetricName()
 {
-  auto msg = generateStatisticMessage(get_name(), MEASUREMENT_TYPE, window_start_,
-      now(), getStatisticsResults());
-  publisher_->publish(msg);
+  return MEASUREMENT_TYPE;
 }
+
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -53,7 +53,7 @@ double LinuxMemoryMeasurementNode::periodicMeasurement()
   return processMemInfoLines(read_string);
 }
 
-std::string LinuxMemoryMeasurementNode::getMetricName()
+std::string LinuxMemoryMeasurementNode::getMetricName() const
 {
   return MEASUREMENT_TYPE;
 }

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -57,9 +57,10 @@ protected:
   double periodicMeasurement() override;
 
   /**
-   * Publish the statistics derived from the collected measurements
+   * Return the name to use for this metric
+   * @return a string of the name for this measured metric
    */
-  void publishStatisticMessage() override;
+  std::string getMetricName() override;
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -60,7 +60,7 @@ protected:
    * Return the name to use for this metric
    * @return a string of the name for this measured metric
    */
-  std::string getMetricName() override;
+  std::string getMetricName() const override;
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -55,8 +55,13 @@ public:
    * ROS2 timer per the publish_period)
    */
   virtual void publishStatisticMessage() = 0;
-};
 
+  /**
+   * Return the name to use for this metric
+   * @return a string of the name for this measured metric
+   */
+  virtual std::string getMetricName() = 0;
+};
 }  // namespace system_metrics_collector
 
 #endif  // SYSTEM_METRICS_COLLECTOR__METRICS_MESSAGE_PUBLISHER_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -60,7 +60,7 @@ public:
    * Return the name to use for this metric
    * @return a string of the name for this measured metric
    */
-  virtual std::string getMetricName() = 0;
+  virtual std::string getMetricName() const = 0;
 };
 }  // namespace system_metrics_collector
 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -88,4 +88,14 @@ void PeriodicMeasurementNode::performPeriodicMeasurement()
   RCLCPP_DEBUG(this->get_logger(), getStatusString());
 }
 
+void PeriodicMeasurementNode::publishStatisticMessage()
+{
+  auto msg = generateStatisticMessage(get_name(),
+      getMetricName(),
+      window_start_,
+      now(),
+      getStatisticsResults());
+  publisher_->publish(msg);
+}
+
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -85,6 +85,10 @@ private:
    */
   virtual void performPeriodicMeasurement();
 
+  /**
+   * Publish the statistics derived from the collected measurements (this is to be called via a
+   * ROS2 timer per the publish_period)
+   */
   void publishStatisticMessage() override;
 
   /**

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -85,6 +85,8 @@ private:
    */
   virtual void performPeriodicMeasurement();
 
+  void publishStatisticMessage() override;
+
   /**
    * Creates a ROS2 timer with a period of measurement_period_.
    *

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -34,6 +34,7 @@ constexpr const std::chrono::milliseconds TEST_LENGTH =
   std::chrono::milliseconds(250);
 constexpr const std::chrono::milliseconds TEST_PERIOD =
   std::chrono::milliseconds(50);
+constexpr const char TEST_METRIC_NAME[] = "test_metric_name";
 }  // namespace
 
 /**
@@ -64,6 +65,11 @@ private:
   }
 
   void publishStatisticMessage() override {}
+
+  std::string getMetricName()
+  {
+    return TEST_METRIC_NAME;
+  }
 
   std::atomic<int> sum{0};
 };

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -66,7 +66,7 @@ private:
 
   void publishStatisticMessage() override {}
 
-  std::string getMetricName()
+  std::string getMetricName() const
   {
     return TEST_METRIC_NAME;
   }


### PR DESCRIPTION
* Add interface to retrieve metric name
* Include units in memory metric name

Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>