### PR TITLE
Process memory measurement

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(system_metrics_collector SHARED
   src/system_metrics_collector/collector.cpp
   src/system_metrics_collector/linux_cpu_measurement_node.cpp
   src/system_metrics_collector/linux_memory_measurement_node.cpp
-  src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+  src/system_metrics_collector/linux_process_memory_measurement_node.cpp
   src/system_metrics_collector/periodic_measurement_node.cpp
   src/system_metrics_collector/proc_cpu_data.cpp
   src/system_metrics_collector/utilities.cpp
@@ -77,6 +77,11 @@ if(BUILD_TESTING)
           test/system_metrics_collector/test_linux_memory_measurement.cpp)
   target_link_libraries(test_linux_memory_measurement_node system_metrics_collector)
   ament_target_dependencies(test_linux_memory_measurement_node metrics_statistics_msgs rclcpp)
+
+  ament_add_gtest(test_linux_process_memory_measurement_node
+          test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp)
+  target_link_libraries(test_linux_process_memory_measurement_node system_metrics_collector)
+  ament_target_dependencies(test_linux_process_memory_measurement_node metrics_statistics_msgs rclcpp)
 
   ament_add_gtest(test_moving_average_statistics
           test/moving_average_statistics/test_moving_average_statistics.cpp)

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(system_metrics_collector SHARED
   src/system_metrics_collector/collector.cpp
   src/system_metrics_collector/linux_cpu_measurement_node.cpp
   src/system_metrics_collector/linux_memory_measurement_node.cpp
+  src/system_metrics_collector/linux_process_memory_measurement_node.hpp
   src/system_metrics_collector/periodic_measurement_node.cpp
   src/system_metrics_collector/proc_cpu_data.cpp
   src/system_metrics_collector/utilities.cpp

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <chrono>
 #include <fstream>
 #include <sstream>

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -1,0 +1,79 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../../src/system_metrics_collector/linux_process_memory_measurement_node.hpp"
+
+#include <sys/sysinfo.h>
+#include <sys/types.h>
+
+#include <chrono>
+#include <cmath>
+#include <sstream>
+#include <string>
+
+#include "rcutils/logging_macros.h"
+
+namespace system_metrics_collector
+{
+
+LinuxProcessMemoryMeasurementNode::LinuxProcessMemoryMeasurementNode(
+  const std::string & name,
+  const std::chrono::milliseconds measurement_period,
+  const std::string & topic,
+  const std::chrono::milliseconds publish_period)
+: PeriodicMeasurementNode(name, measurement_period, topic, publish_period),
+  pid_(std::to_string(getPid())),
+  file_to_read_(PROC + pid_ + STATM)
+{
+}
+
+double LinuxProcessMemoryMeasurementNode::periodicMeasurement()
+{
+  const auto statm_line = readFileToString(file_to_read_);
+  const auto p_mem = getProcessUsedMemory(statm_line);
+  const auto total_mem = getSystemTotalMemory();
+
+  return p_mem / total_mem * 100.0;
+}
+
+std::string LinuxProcessMemoryMeasurementNode::getMetricName() const
+{
+  return pid_ + METRIC_NAME;
+}
+
+double getProcessUsedMemory(
+  const std::string & statm_process_file_contents)
+{
+  std::istringstream ss(statm_process_file_contents);
+  if (ss.good()) {
+    size_t process_memory_used;
+    ss >> process_memory_used;
+    if (ss.good()) {
+      return static_cast<double>(process_memory_used);
+    }
+  }
+
+  RCUTILS_LOG_ERROR_NAMED("getProcessUsedMemory",
+    "unable to parse contents: %s", statm_process_file_contents.c_str());
+  return std::nan("");
+}
+
+double getSystemTotalMemory()
+{
+  struct sysinfo si;
+  auto success = sysinfo(&si);
+  return success == -1 ? std::nan("") : static_cast<double>(si.totalram);
+}
+
+}   // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -36,7 +36,7 @@ namespace
 double getSystemTotalMemory()
 {
   struct sysinfo si;
-  auto success = sysinfo(&si);
+  const auto success = sysinfo(&si);
   return success == -1 ? std::nan("") : static_cast<double>(si.totalram);
 }
 
@@ -80,7 +80,7 @@ std::string LinuxProcessMemoryMeasurementNode::getMetricName() const
 
 uint64_t getProcessUsedMemory(const std::string & statm_process_file_contents)
 {
-  std::istringstream ss(statm_process_file_contents);
+  std::istringstream ss{statm_process_file_contents};
   ss.exceptions(std::ios::failbit | std::ios::badbit);
   uint64_t process_memory_used;
   ss >> process_memory_used;

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -78,13 +78,6 @@ std::string LinuxProcessMemoryMeasurementNode::getMetricName() const
   return pid_ + METRIC_NAME;
 }
 
-/**
-* Return the number of bytes used after parsing a process's statm file.
-*
-* @param statm_process_file the statm file to parse
-* @return the number of bytes used for the statm file's process
- *@throws std::ifstream::failure for std::ios::failbit | std::ios::badbit
-*/
 uint64_t getProcessUsedMemory(const std::string & statm_process_file_contents)
 {
   std::istringstream ss(statm_process_file_contents);

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -1,0 +1,37 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SYSTEM_METRICS_COLLECTOR_LINUX_PROCESS_MEMORY_MEASUREMENT_NODE_HPP
+#define SYSTEM_METRICS_COLLECTOR_LINUX_PROCESS_MEMORY_MEASUREMENT_NODE_HPP
+
+// read /proc/[pid]/status _> VmSize, or statm (first field): http://man7.org/linux/man-pages/man5/proc.5.html
+
+#include <chrono>
+#include <fstream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+
+#include "../../src/system_metrics_collector/linux_memory_measurement_node.hpp"
+#include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/logging_macros.h"
+
+
+class LinuxProcessMemoryMeasurementNode : public LinuxProcessMemoryMeasurementNode
+{
+
+};
+#endif //SYSTEM_METRICS_COLLECTOR_LINUX_PROCESS_MEMORY_MEASUREMENT_NODE_HPP

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -40,6 +40,7 @@ namespace system_metrics_collector
 *
 * @param statm_process_file the statm file to parse
 * @return the number of bytes used for the statm file's process
+ *@throws std::ifstream::failure for std::ios::failbit | std::ios::badbit
 */
 uint64_t getProcessUsedMemory(const std::string & statm_process_file_contents);
 
@@ -63,6 +64,13 @@ public:
     const std::string & topic,
     const std::chrono::milliseconds publish_period);
 
+protected:
+  /**
+   * Return the name to use for this metric
+   * @return a string of the name for this measured metric
+   */
+  std::string getMetricName() const override;
+
 private:
   /**
    * Perform a periodic measurement calculating the percentage of
@@ -73,12 +81,6 @@ private:
    * @return percentage of memory this process used
    */
   double periodicMeasurement() override;
-
-  /**
-   * Return the name to use for this metric
-   * @return a string of the name for this measured metric
-   */
-  std::string getMetricName() const override;
 
   /**
    * The pid of this process/

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -41,14 +41,7 @@ namespace system_metrics_collector
 * @param statm_process_file the statm file to parse
 * @return the number of bytes used for the statm file's process
 */
-double getProcessUsedMemory(const std::string & statm_process_file_contents);
-
-/**
- * Return the total system memory.
- *
- * @return the total system memory in bytes
- */
-double getSystemTotalMemory();
+uint64_t getProcessUsedMemory(const std::string & statm_process_file_contents);
 
 /**
  * Class used to measure the memory percentage used as a process.

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -75,6 +75,14 @@ protected:
     return std::nan("");
   }
 
+void publishStatisticMessage()
+{
+  auto msg = generateStatisticMessage(get_name(), "asdf", window_start_,
+                                      now(), getStatisticsResults());
+  publisher_->publish(msg);
+}
+
+
 private:
   const std::string file_to_read_;
 };

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -82,8 +82,8 @@ int main(int argc, char ** argv)
     RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the process memory node");
   }
 
-  //ex.add_node(cpu_node);
-  //ex.add_node(mem_node);
+  ex.add_node(cpu_node);
+  ex.add_node(mem_node);
   ex.add_node(process_mem_node);
   ex.spin();
 

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -67,20 +67,31 @@ int main(int argc, char ** argv)
   mem_node->start();
   process_mem_node->start();
 
-  auto r = rcutils_logging_set_logger_level(cpu_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-  if (r != 0) {
-    RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the cpu node");
+  {
+    const auto r =
+      rcutils_logging_set_logger_level(cpu_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+    if (r != 0) {
+      RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the cpu node: %s\n",
+        rcutils_get_error_string().str);
+    }
   }
-
-  r = rcutils_logging_set_logger_level(mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-  if (r != 0) {
-    RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the memory node");
+  {
+    const auto r =
+      rcutils_logging_set_logger_level(mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+    if (r != 0) {
+      RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the memory node: %s\n",
+        rcutils_get_error_string().str);
+    }
   }
+  {
+    const auto r = rcutils_logging_set_logger_level(
+      process_mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
 
-  r = rcutils_logging_set_logger_level(process_mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-  if (r != 0) {
-    RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the process memory node");
+    if (r != 0) {
+      RCUTILS_LOG_ERROR_NAMED("main",
+        "Unable to set debug logging for the process memory node: %s\n",
+        rcutils_get_error_string().str);
+    }
   }
 
   ex.add_node(cpu_node);
@@ -94,5 +105,5 @@ int main(int argc, char ** argv)
   mem_node->stop();
   process_mem_node->stop();
 
-  return r;
+  return 0;
 }

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -42,24 +42,25 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
+  using namespace std::chrono_literals;
+  const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
     "linuxCpuCollector",
-    std::chrono::milliseconds(1000),
+    1000ms,
     STATISTICS_TOPIC_NAME,
-    std::chrono::milliseconds(1000 * 60));
+    60s);
 
-  auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
+  const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector",
-    std::chrono::milliseconds(1000),
+    1000ms,
     STATISTICS_TOPIC_NAME,
-    std::chrono::milliseconds(1000 * 60));
+    60s);
 
-  auto process_mem_node =
+  const auto process_mem_node =
     std::make_shared<system_metrics_collector::LinuxProcessMemoryMeasurementNode>(
     "linuxProcessMemoryCollector",
-    std::chrono::milliseconds(1000),
+    1000ms,
     "not_publishing_yet",
-    std::chrono::milliseconds(1000 * 60));
+    60s);
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->start();

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -82,8 +82,8 @@ int main(int argc, char ** argv)
     RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the process memory node");
   }
 
-  ex.add_node(cpu_node);
-  ex.add_node(mem_node);
+  //ex.add_node(cpu_node);
+  //ex.add_node(mem_node);
   ex.add_node(process_mem_node);
   ex.spin();
 

--- a/system_metrics_collector/src/system_metrics_collector/utilities.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <unistd.h>
+
 #include <cmath>
 #include <fstream>
 #include <sstream>

--- a/system_metrics_collector/src/system_metrics_collector/utilities.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.cpp
@@ -36,7 +36,7 @@ std::string readFileToString(const std::string & file_name)
 {
   std::ifstream file_to_read(file_name);
   if (!file_to_read.good()) {
-    RCUTILS_LOG_ERROR_NAMED("readFileToString", "unable to parse file %s", file_name.c_str());
+    RCUTILS_LOG_ERROR_NAMED("readFileToString", "unable to parse file: %s", file_name.c_str());
     return EMPTY_FILE;
   }
 

--- a/system_metrics_collector/src/system_metrics_collector/utilities.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.cpp
@@ -101,4 +101,9 @@ double processMemInfoLines(const std::string & lines)
          std::nan("") : to_return;
 }
 
+int getPid()
+{
+  return getpid();
+}
+
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/utilities.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.hpp
@@ -16,6 +16,7 @@
 #define SYSTEM_METRICS_COLLECTOR__UTILITIES_HPP_
 
 #include <string>
+#include <unistd.h>
 
 namespace system_metrics_collector
 {
@@ -41,6 +42,12 @@ std::string readFileToString(const std::string & file_name);
  * (MemTotal - MemAvailable) / MemTotal * 100.0
  */
 double processMemInfoLines(const std::string & lines);
+
+/**
+ * Return the pid of the current process
+ * @return the pid of the current process as an int
+ */
+int getPid();
 
 }  // namespace system_metrics_collector
 

--- a/system_metrics_collector/src/system_metrics_collector/utilities.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.hpp
@@ -15,8 +15,8 @@
 #ifndef SYSTEM_METRICS_COLLECTOR__UTILITIES_HPP_
 #define SYSTEM_METRICS_COLLECTOR__UTILITIES_HPP_
 
-#include <string>
 #include <unistd.h>
+#include <string>
 
 namespace system_metrics_collector
 {

--- a/system_metrics_collector/src/system_metrics_collector/utilities.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.hpp
@@ -15,7 +15,6 @@
 #ifndef SYSTEM_METRICS_COLLECTOR__UTILITIES_HPP_
 #define SYSTEM_METRICS_COLLECTOR__UTILITIES_HPP_
 
-#include <unistd.h>
 #include <string>
 
 namespace system_metrics_collector

--- a/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
@@ -48,10 +48,13 @@ public:
   void SetUp() override
   {
     test_collector = std::make_unique<TestCollector>();
+    ASSERT_FALSE(test_collector->isStarted());
   }
 
   void TearDown() override
   {
+    test_collector->stop();  // don't assert as tests can call stop
+    ASSERT_FALSE(test_collector->isStarted());
     test_collector.reset();
   }
 
@@ -70,6 +73,7 @@ TEST_F(CollectorTestFixure, test_add_and_clear_measurement) {
   ASSERT_EQ(1, stats.average);
 
   test_collector->clearCurrentMeasurements();
+
   stats = test_collector->getStatisticsResults();
   ASSERT_TRUE(std::isnan(stats.average));
   ASSERT_TRUE(std::isnan(stats.min));
@@ -82,8 +86,12 @@ TEST_F(CollectorTestFixure, test_start_and_stop) {
   ASSERT_FALSE(test_collector->isStarted());
   ASSERT_EQ("started=false, avg=nan, min=nan, max=nan, std_dev=nan, count=0",
     test_collector->getStatusString());
+
   ASSERT_TRUE(test_collector->start());
   ASSERT_TRUE(test_collector->isStarted());
   ASSERT_EQ("started=true, avg=nan, min=nan, max=nan, std_dev=nan, count=0",
     test_collector->getStatusString());
+
+  ASSERT_TRUE(test_collector->stop());
+  ASSERT_FALSE(test_collector->isStarted());
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -148,6 +148,7 @@ public:
   void TearDown() override
   {
     test_measure_linux_memory->stop();
+    ASSERT_FALSE(test_measure_linux_memory->isStarted());
     test_measure_linux_memory.reset();
     rclcpp::shutdown();
   }

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -1,0 +1,36 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+
+#include <cmath>
+#include "../../src/system_metrics_collector/linux_process_memory_measurement_node.hpp"
+
+#include "test_constants.hpp"
+
+
+namespace
+{
+constexpr const char TEST_STATM_LINE[] = "2084389 308110 7390 1 0 366785 0\n";
+}
+
+TEST(TestLinuxProcessMemoryMeasurement, testGetProcessUsedMemory) {
+  auto ret = system_metrics_collector::getProcessUsedMemory(test_constants::GARBAGE_SAMPLE);
+  EXPECT_TRUE(std::isnan(ret));
+  ret = system_metrics_collector::getProcessUsedMemory(test_constants::EMPTY_SAMPLE);
+  EXPECT_TRUE(std::isnan(ret));
+  ret = system_metrics_collector::getProcessUsedMemory(TEST_STATM_LINE);
+  EXPECT_EQ(2084389, ret);
+}

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -15,16 +15,74 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <memory>
 #include <fstream>
+#include <string>
+
 #include "../../src/system_metrics_collector/linux_process_memory_measurement_node.hpp"
+#include "../../src/system_metrics_collector/utilities.hpp"
 
 #include "test_constants.hpp"
-
 
 namespace
 {
 constexpr const char TEST_STATM_LINE[] = "2084389 308110 7390 1 0 366785 0\n";
 }
+
+class TestLinuxProcessMemoryMeasurementNode : public system_metrics_collector::
+  LinuxProcessMemoryMeasurementNode
+{
+public:
+  TestLinuxProcessMemoryMeasurementNode(
+    const std::string & name,
+    const std::chrono::milliseconds measurement_period,
+    const std::string & topic,
+    const std::chrono::milliseconds publish_period)
+  : LinuxProcessMemoryMeasurementNode(name, measurement_period, topic, publish_period) {}
+
+  std::string getMetricName() const override
+  {
+    return LinuxProcessMemoryMeasurementNode::getMetricName();
+  }
+};
+
+class LinuxProcessMemoryMeasurementTestFixture : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    using namespace std::chrono_literals;
+
+    test_node = std::make_shared<TestLinuxProcessMemoryMeasurementNode>(
+      "test_periodic_node",
+      1s,
+      "test_topic",
+      10s);
+
+    ASSERT_FALSE(test_node->isStarted());
+
+    const moving_average_statistics::StatisticData data =
+      test_node->getStatisticsResults();
+    ASSERT_TRUE(std::isnan(data.average));
+    ASSERT_TRUE(std::isnan(data.min));
+    ASSERT_TRUE(std::isnan(data.max));
+    ASSERT_TRUE(std::isnan(data.standard_deviation));
+    ASSERT_EQ(0, data.sample_count);
+  }
+
+  void TearDown() override
+  {
+    test_node->stop();
+    ASSERT_FALSE(test_node->isStarted());
+    test_node.reset();
+    rclcpp::shutdown();
+  }
+
+protected:
+  std::shared_ptr<TestLinuxProcessMemoryMeasurementNode> test_node;
+};
+
 
 TEST(TestLinuxProcessMemoryMeasurement, testGetProcessUsedMemory) {
   EXPECT_THROW(system_metrics_collector::getProcessUsedMemory(
@@ -34,4 +92,10 @@ TEST(TestLinuxProcessMemoryMeasurement, testGetProcessUsedMemory) {
 
   const auto ret = system_metrics_collector::getProcessUsedMemory(TEST_STATM_LINE);
   EXPECT_EQ(2084389, ret);
+}
+
+TEST_F(LinuxProcessMemoryMeasurementTestFixture, testGetMetricName) {
+  const auto pid = system_metrics_collector::getPid();
+
+  ASSERT_EQ(std::to_string(pid) + "_memory_percent_used", test_node->getMetricName());
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -14,8 +14,8 @@
 
 #include <gtest/gtest.h>
 
-
 #include <cmath>
+#include <fstream>
 #include "../../src/system_metrics_collector/linux_process_memory_measurement_node.hpp"
 
 #include "test_constants.hpp"
@@ -27,10 +27,11 @@ constexpr const char TEST_STATM_LINE[] = "2084389 308110 7390 1 0 366785 0\n";
 }
 
 TEST(TestLinuxProcessMemoryMeasurement, testGetProcessUsedMemory) {
-  auto ret = system_metrics_collector::getProcessUsedMemory(test_constants::GARBAGE_SAMPLE);
-  EXPECT_TRUE(std::isnan(ret));
-  ret = system_metrics_collector::getProcessUsedMemory(test_constants::EMPTY_SAMPLE);
-  EXPECT_TRUE(std::isnan(ret));
-  ret = system_metrics_collector::getProcessUsedMemory(TEST_STATM_LINE);
+  EXPECT_THROW(system_metrics_collector::getProcessUsedMemory(
+      test_constants::GARBAGE_SAMPLE), std::ifstream::failure);
+  EXPECT_THROW(system_metrics_collector::getProcessUsedMemory(
+      test_constants::EMPTY_SAMPLE), std::ifstream::failure);
+
+  const auto ret = system_metrics_collector::getProcessUsedMemory(TEST_STATM_LINE);
   EXPECT_EQ(2084389, ret);
 }


### PR DESCRIPTION
Added functionality to measure the process memory (percentage used) by extending a PeriodicMeasurementNode. See https://github.com/ros-security/aws-roadmap/issues/139 for details.