### PR TITLE
Use uint64_t for /proc/stat cpu parsed type

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.cpp
@@ -22,13 +22,13 @@ namespace system_metrics_collector
 
 /*static*/ constexpr const char ProcCpuData::EMPTY_LABEL[];
 
-size_t ProcCpuData::getIdleTime() const
+uint64_t ProcCpuData::getIdleTime() const
 {
   return times[static_cast<int>(ProcCpuStates::kIdle)] +
          times[static_cast<int>(ProcCpuStates::kIOWait)];
 }
 
-size_t ProcCpuData::getActiveTime() const
+uint64_t ProcCpuData::getActiveTime() const
 {
   return times[static_cast<int>(ProcCpuStates::kUser)] +
          times[static_cast<int>(ProcCpuStates::kNice)] +

--- a/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.hpp
@@ -53,13 +53,13 @@ public:
    * Return the idle time
    * @return the idle time for this data set
    */
-  size_t getIdleTime() const;
+  uint64_t getIdleTime() const;
 
   /**
    * Return the active time
    * @return the active time for this data set
    */
-  size_t getActiveTime() const;
+  uint64_t getActiveTime() const;
 
   /**
    * Return a pretty printed string of the ProcCpuData struct.
@@ -86,7 +86,7 @@ public:
    * Array contained the parsed CPU data, where each index
    * of ProcCpuStates contains its labeled data.
    */
-  std::array<size_t, static_cast<int>(ProcCpuStates::kNumProcCpuStates)> times{};
+  std::array<uint64_t, static_cast<int>(ProcCpuStates::kNumProcCpuStates)> times{};
 };
 
 }  // namespace system_metrics_collector


### PR DESCRIPTION
After reviewing, with @thomas-moulard,  the behavior and source code for generating the /proc/stat values, the type has been updated to properly reflect the possible bounded value. 