### PR TITLE
Remove clear_measurements_on_publish

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -30,15 +30,13 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
   const std::string & name,
   const std::chrono::milliseconds measurement_period,
   const std::string & publishing_topic,
-  const std::chrono::milliseconds publish_period,
-  const bool clear_measurements_on_publish)
+  const std::chrono::milliseconds publish_period)
 : Node(name),
   measurement_period_(measurement_period),
   publishing_topic_(publishing_topic),
   measurement_timer_(nullptr),
   publish_timer_(nullptr),
-  publish_period_(publish_period),
-  clear_measurements_on_publish_(clear_measurements_on_publish)
+  publish_period_(publish_period)
 {
   if (publish_period_ <= std::chrono::milliseconds(0)) {
     throw std::invalid_argument("publish period cannot be negative");
@@ -62,10 +60,8 @@ bool PeriodicMeasurementNode::setupStart()
   publish_timer_ = this->create_wall_timer(
     publish_period_, [this]() {
       this->publishStatisticMessage();
-      if (this->clear_measurements_on_publish_) {
-        this->clearCurrentMeasurements();
-        this->window_start_ = this->now();
-      }
+      this->clearCurrentMeasurements();
+      this->window_start_ = this->now();
     });
 
   window_start_ = now();
@@ -95,7 +91,6 @@ std::string PeriodicMeasurementNode::getStatusString() const
     ", measurement_period=" << std::to_string(measurement_period_.count()) << "ms" <<
     ", publishing_topic=" << publishing_topic_ <<
     ", publish_period=" << std::to_string(publish_period_.count()) + "ms" <<
-    ", clear_measurements_on_publish_=" << clear_measurements_on_publish_ <<
     ", " << Collector::getStatusString();
   return ss.str();
 }

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -50,8 +50,7 @@ public:
     const std::string & name,
     const std::chrono::milliseconds measurement_period,
     const std::string & topic,  // todo @dbbonnie think about a default topic
-    const std::chrono::milliseconds publish_period,
-    const bool clear_measurements_on_publish = true);
+    const std::chrono::milliseconds publish_period);
 
   virtual ~PeriodicMeasurementNode() = default;
 
@@ -118,10 +117,6 @@ private:
    * The period used to publish measurement data
    */
   const std::chrono::milliseconds publish_period_;
-  /**
-   * If true, then measurements are cleared after publishing data
-   */
-  const bool clear_measurements_on_publish_;
 
   rclcpp::TimerBase::SharedPtr measurement_timer_;
   rclcpp::TimerBase::SharedPtr publish_timer_;

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -45,11 +45,8 @@ public:
     const std::string & name,
     const std::chrono::milliseconds measurement_period,
     const std::string & publishing_topic,
-    const std::chrono::milliseconds publish_period,
-    const bool clear_measurements_on_publish)
-  : PeriodicMeasurementNode(name, measurement_period, publishing_topic, publish_period,
-      clear_measurements_on_publish)
-  {}
+    const std::chrono::milliseconds publish_period)
+  : PeriodicMeasurementNode(name, measurement_period, publishing_topic, publish_period) {}
   virtual ~TestPeriodicMeasurementNode() = default;
 
   int getNumPublished() const
@@ -99,7 +96,7 @@ public:
     rclcpp::init(0, nullptr);
 
     test_periodic_measurer = std::make_shared<TestPeriodicMeasurementNode>(TEST_NODE_NAME,
-        test_constants::MEASURE_PERIOD, TEST_TOPIC, test_constants::PUBLISH_PERIOD, false);
+        test_constants::MEASURE_PERIOD, TEST_TOPIC, INFREQUENT_PUBLISH_PERIOD);
 
     ASSERT_FALSE(test_periodic_measurer->isStarted());
 
@@ -120,14 +117,17 @@ public:
   }
 
 protected:
+  static constexpr std::chrono::milliseconds INFREQUENT_PUBLISH_PERIOD = 2 *
+    test_constants::TEST_DURATION;
   std::shared_ptr<TestPeriodicMeasurementNode> test_periodic_measurer;
 };
+
+constexpr std::chrono::milliseconds PeriodicMeasurementTestFixure::INFREQUENT_PUBLISH_PERIOD;
 
 TEST_F(PeriodicMeasurementTestFixure, sanity) {
   ASSERT_NE(test_periodic_measurer, nullptr);
   ASSERT_EQ("name=test_periodic_node, measurement_period=50ms,"
-    " publishing_topic=test_topic, publish_period=80ms,"
-    " clear_measurements_on_publish_=0, started=false,"
+    " publishing_topic=test_topic, publish_period=500ms, started=false,"
     " avg=nan, min=nan, max=nan, std_dev=nan, count=0",
     test_periodic_measurer->getStatusString());
 }
@@ -163,8 +163,7 @@ TEST_F(PeriodicMeasurementTestFixure, test_start_and_stop) {
 
   int times_published = test_periodic_measurer->getNumPublished();
   ASSERT_EQ(
-    test_constants::TEST_DURATION.count() / test_constants::PUBLISH_PERIOD.count(),
-    times_published);
+    test_constants::TEST_DURATION.count() / INFREQUENT_PUBLISH_PERIOD.count(), times_published);
 }
 
 int main(int argc, char ** argv)

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -96,7 +96,7 @@ public:
     rclcpp::init(0, nullptr);
 
     test_periodic_measurer = std::make_shared<TestPeriodicMeasurementNode>(TEST_NODE_NAME,
-        test_constants::MEASURE_PERIOD, TEST_TOPIC, INFREQUENT_PUBLISH_PERIOD);
+        test_constants::MEASURE_PERIOD, TEST_TOPIC, DONT_PUBLISH_DURING_TEST);
 
     ASSERT_FALSE(test_periodic_measurer->isStarted());
 
@@ -117,12 +117,15 @@ public:
   }
 
 protected:
-  static constexpr std::chrono::milliseconds INFREQUENT_PUBLISH_PERIOD = 2 *
+  // this test is not designed to have the statistics published and reset at any point of the test,
+  // so this is defining the publish period to be something amply larger than the test duration
+  // itself
+  static constexpr std::chrono::milliseconds DONT_PUBLISH_DURING_TEST = 2 *
     test_constants::TEST_DURATION;
   std::shared_ptr<TestPeriodicMeasurementNode> test_periodic_measurer;
 };
 
-constexpr std::chrono::milliseconds PeriodicMeasurementTestFixure::INFREQUENT_PUBLISH_PERIOD;
+constexpr std::chrono::milliseconds PeriodicMeasurementTestFixure::DONT_PUBLISH_DURING_TEST;
 
 TEST_F(PeriodicMeasurementTestFixure, sanity) {
   ASSERT_NE(test_periodic_measurer, nullptr);
@@ -163,7 +166,7 @@ TEST_F(PeriodicMeasurementTestFixure, test_start_and_stop) {
 
   int times_published = test_periodic_measurer->getNumPublished();
   ASSERT_EQ(
-    test_constants::TEST_DURATION.count() / INFREQUENT_PUBLISH_PERIOD.count(), times_published);
+    test_constants::TEST_DURATION.count() / DONT_PUBLISH_DURING_TEST.count(), times_published);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
As alluded to at https://github.com/ros-tooling/system_metrics_collector/pull/16#discussion_r352762504, this change removes the `clear_measurements_on_publish` argument from `PeriodicMeasurementNode`, treating it as if it was always `true`.