### PR TITLE
Fix function erroneously declared as static

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(rcutils REQUIRED)
 
 add_library(system_metrics_collector SHARED
   src/moving_average_statistics/moving_average.cpp
+  src/moving_average_statistics/types.cpp
   src/moving_average_statistics/types.hpp
   src/system_metrics_collector/metrics_message_publisher.cpp
   src/system_metrics_collector/collector.cpp

--- a/system_metrics_collector/src/moving_average_statistics/types.cpp
+++ b/system_metrics_collector/src/moving_average_statistics/types.cpp
@@ -1,0 +1,32 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sstream>
+#include <string>
+
+#include "types.hpp"
+
+namespace moving_average_statistics
+{
+
+std::string statisticsDataToString(const StatisticData & results)
+{
+  std::stringstream ss;
+  ss << "avg=" << std::to_string(results.average) << ", min=" << std::to_string(results.min) <<
+    ", max=" << std::to_string(results.max) << ", std_dev=" << std::to_string(
+    results.standard_deviation) << ", count=" << std::to_string(results.sample_count);
+  return ss.str();
+}
+
+}  // namespace moving_average_statistics

--- a/system_metrics_collector/src/moving_average_statistics/types.hpp
+++ b/system_metrics_collector/src/moving_average_statistics/types.hpp
@@ -41,14 +41,7 @@ struct StatisticData
  * @return std::string formatted struct contents in an easily readable format, e.g.,
  * /"avg=1, min=2, max=3, std_dev=4, count=5/"
  */
-static std::string statisticsDataToString(const StatisticData & results)
-{
-  std::stringstream ss;
-  ss << "avg=" << std::to_string(results.average) << ", min=" << std::to_string(results.min) <<
-    ", max=" << std::to_string(results.max) << ", std_dev=" << std::to_string(
-    results.standard_deviation) << ", count=" << std::to_string(results.sample_count);
-  return ss.str();
-}
+std::string statisticsDataToString(const StatisticData & results);
 
 }  // namespace moving_average_statistics
 


### PR DESCRIPTION
Functions declared in headers should never be static.
In the previous implementation, statisticsDataToString was duplicated
in each compilation unit as the function was both defined in the header
and declared as static.