### PR TITLE
Move private constants to .cpp file

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -28,6 +28,10 @@
 namespace
 {
 
+constexpr const char PROC[] = "/proc/";
+constexpr const char STATM[] = "/statm";
+constexpr const char METRIC_NAME[] = "_memory_percent_used";
+
 /**
  * Return the total system memory.
  *

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -25,12 +25,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/logging_macros.h"
 
-namespace
-{
-constexpr const char PROC[] = "/proc/";
-constexpr const char STATM[] = "/statm";
-constexpr const char METRIC_NAME[] = "_memory_percent_used";
-}  // namespace
 
 namespace system_metrics_collector
 {


### PR DESCRIPTION
Move what seems to be private constants from the `.hpp` header file to the `.cpp` file. This makes it more consistent with the other measurement nodes.