### PR TITLE
Remove Microsoft's repos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         linter: [copyright, cppcheck, cpplint, flake8, pep257, uncrustify, xmllint]
     steps:
+      - name: "Temporarily remove MS apt sources. https://github.com/ros-security/aws-oncall/issues/31"
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
       - uses: actions/checkout@v1
       - uses: ros-tooling/setup-ros2@0.0.5
       - uses: ros-tooling/action-ros2-lint@0.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,27 +17,31 @@ jobs:
       matrix:
           os: [ubuntu-18.04]
     steps:
-    - uses: ros-tooling/setup-ros2@0.0.6
-    - uses: ros-tooling/action-ros2-ci@0.0.10
-      with:
-        package-name: system_metrics_collector
-        colcon-mixin-name: coverage-gcc
-        colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-    - uses: codecov/codecov-action@v1
-      # Prevent being rate limited by only reporting coverage from the Ubuntu
-      # build.
-      if: matrix.os == 'ubuntu-18.04'
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ros2_ws/lcov/total_coverage.info
-        flags: unittests
-        name: codecov-umbrella
-        yml: ./codecov.yml
-        fail_ci_if_error: true
-    - uses: actions/upload-artifact@master
-      with:
-        name: colcon-logs-${{ matrix.os }}
-        path: ros2_ws/log
+      - name: "Temporarily remove MS apt sources. https://github.com/ros-security/aws-oncall/issues/31"
+        if: matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+      - uses: ros-tooling/setup-ros2@0.0.6
+      - uses: ros-tooling/action-ros2-ci@0.0.10
+        with:
+          package-name: system_metrics_collector
+          colcon-mixin-name: coverage-gcc
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v1
+        # Prevent being rate limited by only reporting coverage from the Ubuntu
+        # build.
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ros2_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
+          yml: ./codecov.yml
+          fail_ci_if_error: true
+      - uses: actions/upload-artifact@master
+        with:
+          name: colcon-logs-${{ matrix.os }}
+          path: ros2_ws/log
 
   build_and_test_asan:
     runs-on: ${{ matrix.os }}
@@ -46,13 +50,17 @@ jobs:
       matrix:
           os: [ubuntu-18.04]
     steps:
-    - uses: ros-tooling/setup-ros2@0.0.6
-    - uses: ros-tooling/action-ros2-ci@0.0.10
-      with:
-        colcon-mixin-name: asan
-        colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-        package-name: system_metrics_collector
-    - uses: actions/upload-artifact@master
-      with:
-        name: colcon-logs-${{ matrix.os }}-asan
-        path: ros2_ws/log
+      - name: "Temporarily remove MS apt sources. https://github.com/ros-security/aws-oncall/issues/31"
+        if: matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+      - uses: ros-tooling/setup-ros2@0.0.6
+      - uses: ros-tooling/action-ros2-ci@0.0.10
+        with:
+          colcon-mixin-name: asan
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+          package-name: system_metrics_collector
+      - uses: actions/upload-artifact@master
+        with:
+          name: colcon-logs-${{ matrix.os }}-asan
+          path: ros2_ws/log


### PR DESCRIPTION
Add a step to the build and test workflow removing the MS repos causing the workflow to fail.

A PR that reverts this change needs to be created and merged once an official fix has been released.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>