### PR TITLE
Style guide constants

### DIFF
--- a/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
+++ b/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
@@ -51,7 +51,7 @@ StatisticData MovingAverageStatistics::getStatistics() const
 {
   std::lock_guard<std::mutex> guard{mutex};
   StatisticData to_return;
-  
+
   if (count_ == 0) {
     return to_return;  // already initialized
   }

--- a/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
+++ b/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
@@ -51,8 +51,7 @@ StatisticData MovingAverageStatistics::getStatistics() const
 {
   std::lock_guard<std::mutex> guard{mutex};
   StatisticData to_return;
-
-
+  
   if (count_ == 0) {
     return to_return;  // already initialized
   }

--- a/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
+++ b/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
@@ -49,7 +49,7 @@ double MovingAverageStatistics::standardDeviation() const
 
 StatisticData MovingAverageStatistics::getStatistics() const
 {
-  std::lock_guard<std::mutex> guard(mutex);
+  std::lock_guard<std::mutex> guard{mutex};
   StatisticData to_return;
 
   if (count_ == 0) {
@@ -68,7 +68,7 @@ StatisticData MovingAverageStatistics::getStatistics() const
 
 void MovingAverageStatistics::reset()
 {
-  std::lock_guard<std::mutex> guard(mutex);
+  std::lock_guard<std::mutex> guard{mutex};
   average_ = 0;
   min_ = std::numeric_limits<double>::max();
   max_ = std::numeric_limits<double>::min();
@@ -78,7 +78,7 @@ void MovingAverageStatistics::reset()
 
 void MovingAverageStatistics::addMeasurement(const double item)
 {
-  std::lock_guard<std::mutex> guard(mutex);
+  std::lock_guard<std::mutex> guard{mutex};
 
   if (!std::isnan(item)) {
     count_++;
@@ -93,7 +93,7 @@ void MovingAverageStatistics::addMeasurement(const double item)
 
 uint64_t MovingAverageStatistics::getCount() const
 {
-  std::lock_guard<std::mutex> guard(mutex);
+  std::lock_guard<std::mutex> guard{mutex};
   return count_;
 }
 

--- a/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
+++ b/system_metrics_collector/src/moving_average_statistics/moving_average.cpp
@@ -52,6 +52,7 @@ StatisticData MovingAverageStatistics::getStatistics() const
   std::lock_guard<std::mutex> guard{mutex};
   StatisticData to_return;
 
+
   if (count_ == 0) {
     return to_return;  // already initialized
   }

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -29,8 +29,8 @@ using metrics_statistics_msgs::msg::MetricsMessage;
 
 namespace
 {
-constexpr const char MEASUREMENT_TYPE[] = "system_cpu_percent_used";
-constexpr const char PROC_STAT_FILE[] = "/proc/stat";
+constexpr const char kMeasurementType[] = "system_cpu_percent_used";
+constexpr const char kProcStatFile[] = "/proc/stat";
 }  // namespace
 
 namespace system_metrics_collector
@@ -66,9 +66,9 @@ double LinuxCpuMeasurementNode::periodicMeasurement()
 
 system_metrics_collector::ProcCpuData LinuxCpuMeasurementNode::makeSingleMeasurement()
 {
-  std::ifstream stat_file(PROC_STAT_FILE);
+  std::ifstream stat_file{kProcStatFile};
   if (!stat_file.good()) {
-    RCLCPP_ERROR(this->get_logger(), "unable to open file %s", PROC_STAT_FILE);
+    RCLCPP_ERROR(this->get_logger(), "unable to open file %s", kProcStatFile);
     return system_metrics_collector::ProcCpuData();
   }
   std::string line;
@@ -84,7 +84,7 @@ system_metrics_collector::ProcCpuData LinuxCpuMeasurementNode::makeSingleMeasure
 
 std::string LinuxCpuMeasurementNode::getMetricName() const
 {
-  return MEASUREMENT_TYPE;
+  return kMeasurementType;
 }
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -29,8 +29,8 @@ using metrics_statistics_msgs::msg::MetricsMessage;
 
 namespace
 {
-constexpr const char MEASUREMENT_TYPE[] = "system_memory_percent_used";
-constexpr const char PROC_STAT_FILE[] = "/proc/meminfo";
+constexpr const char kMeasurementType[] = "system_memory_percent_used";
+constexpr const char kProcStatFile[] = "/proc/meminfo";
 }  // namespace
 
 namespace system_metrics_collector
@@ -47,17 +47,17 @@ LinuxMemoryMeasurementNode::LinuxMemoryMeasurementNode(
 
 double LinuxMemoryMeasurementNode::periodicMeasurement()
 {
-  std::ifstream stat_file(PROC_STAT_FILE);
+  std::ifstream stat_file{kProcStatFile};
   if (!stat_file.good()) {
     return std::nan("");
   }
-  auto read_string = readFileToString(PROC_STAT_FILE);
+  auto read_string = readFileToString(kProcStatFile);
   return processMemInfoLines(read_string);
 }
 
 std::string LinuxMemoryMeasurementNode::getMetricName() const
 {
-  return MEASUREMENT_TYPE;
+  return kMeasurementType;
 }
 
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -28,9 +28,9 @@
 namespace
 {
 
-constexpr const char PROC[] = "/proc/";
-constexpr const char STATM[] = "/statm";
-constexpr const char METRIC_NAME[] = "_memory_percent_used";
+constexpr const char kProc[] = "/proc/";
+constexpr const char kStatm[] = "/statm";
+constexpr const char kMetricName[] = "_memory_percent_used";
 
 /**
  * Return the total system memory.
@@ -56,7 +56,7 @@ LinuxProcessMemoryMeasurementNode::LinuxProcessMemoryMeasurementNode(
   const std::chrono::milliseconds publish_period)
 : PeriodicMeasurementNode(name, measurement_period, topic, publish_period),
   pid_(std::to_string(getPid())),
-  file_to_read_(PROC + pid_ + STATM)
+  file_to_read_(kProc + std::to_string(getPid()) + kStatm)
 {
 }
 
@@ -79,7 +79,7 @@ double LinuxProcessMemoryMeasurementNode::periodicMeasurement()
 
 std::string LinuxProcessMemoryMeasurementNode::getMetricName() const
 {
-  return pid_ + METRIC_NAME;
+  return pid_ + kMetricName;
 }
 
 uint64_t getProcessUsedMemory(const std::string & statm_process_file_contents)

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -28,8 +28,10 @@
 
 namespace
 {
-constexpr const char STATISTICS_TOPIC_NAME[] = "system_metrics";
-}
+constexpr const char kStatisticsTopicName[] = "system_metrics";
+constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
+constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
+}  // namespace
 
 /**
  * This is current a "test" main in order to manually test the measurement nodes.
@@ -45,22 +47,22 @@ int main(int argc, char ** argv)
   using namespace std::chrono_literals;
   const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
     "linuxCpuCollector",
-    1000ms,
-    STATISTICS_TOPIC_NAME,
-    60s);
+    kDefaultCollectPeriod,
+    kStatisticsTopicName,
+    kDefaultPublishPeriod);
 
   const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector",
-    1000ms,
-    STATISTICS_TOPIC_NAME,
-    60s);
+    kDefaultCollectPeriod,
+    kStatisticsTopicName,
+    kDefaultPublishPeriod);
 
   const auto process_mem_node =
     std::make_shared<system_metrics_collector::LinuxProcessMemoryMeasurementNode>(
     "linuxProcessMemoryCollector",
-    1000ms,
+    kDefaultCollectPeriod,
     "not_publishing_yet",
-    60s);
+    kDefaultPublishPeriod);
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->start();

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -38,7 +38,7 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
   publish_timer_(nullptr),
   publish_period_(publish_period)
 {
-  if (publish_period_ <= std::chrono::milliseconds(0)) {
+  if (publish_period_ <= std::chrono::milliseconds{0}) {
     throw std::invalid_argument("publish period cannot be negative");
   }
 }

--- a/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.cpp
@@ -20,7 +20,7 @@
 namespace system_metrics_collector
 {
 
-/*static*/ constexpr const char ProcCpuData::EMPTY_LABEL[];
+/*static*/ constexpr const char ProcCpuData::kEmptyLabel[];
 
 uint64_t ProcCpuData::getIdleTime() const
 {
@@ -55,7 +55,7 @@ std::string ProcCpuData::toString() const
 
 bool ProcCpuData::isMeasurementEmpty() const
 {
-  return cpu_label == ProcCpuData::EMPTY_LABEL;
+  return cpu_label == ProcCpuData::kEmptyLabel;
 }
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/proc_cpu_data.hpp
@@ -47,7 +47,7 @@ public:
   ProcCpuData() = default;
   virtual ~ProcCpuData() = default;
 
-  static constexpr const char EMPTY_LABEL[] = "empty";
+  static constexpr const char kEmptyLabel[] = "empty";
 
   /**
    * Return the idle time
@@ -80,7 +80,7 @@ public:
   /**
    * The cpu label of the line parsed
    */
-  std::string cpu_label{EMPTY_LABEL};
+  std::string cpu_label{kEmptyLabel};
 
   /**
    * Array contained the parsed CPU data, where each index

--- a/system_metrics_collector/src/system_metrics_collector/utilities.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.cpp
@@ -32,7 +32,7 @@ namespace
 constexpr const char kCpuLabel[] = "cpu";
 constexpr const char kMemTotal[] = "MemTotal:";
 constexpr const char kMemAvailable[] = "MemAvailable:";
-constexpr const char kEmptyFilekEmptyFile[] = "";
+constexpr const char kEmptyFile[] = "";
 constexpr const int kInvalidMemorySample = -1;
 
 double computeCpuTotalTime(const ProcCpuData measurement1, const ProcCpuData measurement2)
@@ -49,7 +49,7 @@ std::string readFileToString(const std::string & file_name)
   std::ifstream file_to_read{file_name};
   if (!file_to_read.good()) {
     RCUTILS_LOG_ERROR_NAMED("readFileToString", "unable to parse file: %s", file_name.c_str());
-    return kMemAvailable;
+    return kEmptyFile;
   }
 
   std::string to_return((std::istreambuf_iterator<char>(file_to_read)),

--- a/system_metrics_collector/src/system_metrics_collector/utilities.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.cpp
@@ -29,11 +29,11 @@ namespace system_metrics_collector
 namespace
 {
 
-constexpr const char CPU_LABEL[] = "cpu";
-constexpr const char MEM_TOTAL[] = "MemTotal:";
-constexpr const char MEM_AVAILABLE[] = "MemAvailable:";
-constexpr const char EMPTY_FILE[] = "";
-constexpr const int INVALID_MEMORY_SAMPLE = -1;
+constexpr const char kCpuLabel[] = "cpu";
+constexpr const char kMemTotal[] = "MemTotal:";
+constexpr const char kMemAvailable[] = "MemAvailable:";
+constexpr const char kEmptyFilekEmptyFile[] = "";
+constexpr const int kInvalidMemorySample = -1;
 
 double computeCpuTotalTime(const ProcCpuData measurement1, const ProcCpuData measurement2)
 {
@@ -46,10 +46,10 @@ double computeCpuTotalTime(const ProcCpuData measurement1, const ProcCpuData mea
 
 std::string readFileToString(const std::string & file_name)
 {
-  std::ifstream file_to_read(file_name);
+  std::ifstream file_to_read{file_name};
   if (!file_to_read.good()) {
     RCUTILS_LOG_ERROR_NAMED("readFileToString", "unable to parse file: %s", file_name.c_str());
-    return EMPTY_FILE;
+    return kMemAvailable;
   }
 
   std::string to_return((std::istreambuf_iterator<char>(file_to_read)),
@@ -63,7 +63,7 @@ ProcCpuData processStatCpuLine(const std::string & stat_cpu_line)
   ProcCpuData parsed_data;
 
   if (!stat_cpu_line.empty()) {
-    if (!stat_cpu_line.compare(0, strlen(CPU_LABEL), CPU_LABEL)) {
+    if (!stat_cpu_line.compare(0, strlen(kCpuLabel), kCpuLabel)) {
       std::istringstream ss(stat_cpu_line);
 
       if (!ss.good()) {
@@ -111,8 +111,8 @@ double processMemInfoLines(const std::string & lines)
 
   std::string line;
 
-  int total = INVALID_MEMORY_SAMPLE;
-  int available = INVALID_MEMORY_SAMPLE;
+  int total = kInvalidMemorySample;
+  int available = kInvalidMemorySample;
 
   std::istringstream parse_line("");      // parse each line from the input
   std::string tlabel;
@@ -120,30 +120,30 @@ double processMemInfoLines(const std::string & lines)
   while (std::getline(process_lines_stream, line) && process_lines_stream.good()) {
     parse_line.str(line);
 
-    if (!line.compare(0, strlen(MEM_TOTAL), MEM_TOTAL)) {
+    if (!line.compare(0, strlen(kMemTotal), kMemTotal)) {
       parse_line >> tlabel;
       if (!parse_line.good()) {
-        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s label", MEM_TOTAL);
+        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s label", kMemTotal);
         return std::nan("");
       }
 
       parse_line >> total;
       if (!parse_line.good()) {
-        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s value", MEM_TOTAL);
+        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s value", kMemTotal);
         return std::nan("");
       }
-    } else if (!line.compare(0, strlen(MEM_AVAILABLE), MEM_AVAILABLE)) {
+    } else if (!line.compare(0, strlen(kMemAvailable), kMemAvailable)) {
       std::string tlabel;
 
       parse_line >> tlabel;
       if (!parse_line.good()) {
-        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s label", MEM_AVAILABLE);
+        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s label", kMemAvailable);
         return std::nan("");
       }
 
       parse_line >> available;
       if (!parse_line.good()) {
-        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s value", MEM_AVAILABLE);
+        RCUTILS_LOG_ERROR_NAMED("processMemInfoLines", "unable to parse %s value", kMemAvailable);
         return std::nan("");
       }
       break;      // no need to parse other lines after this label
@@ -152,7 +152,7 @@ double processMemInfoLines(const std::string & lines)
   }
   const double to_return = static_cast<double>(total - available) / static_cast<double>(total) *
     100.0;
-  return total == INVALID_MEMORY_SAMPLE || available == INVALID_MEMORY_SAMPLE ?
+  return total == kInvalidMemorySample || available == kInvalidMemorySample ?
          std::nan("") : to_return;
 }
 

--- a/system_metrics_collector/test/moving_average_statistics/test_moving_average_statistics.cpp
+++ b/system_metrics_collector/test/moving_average_statistics/test_moving_average_statistics.cpp
@@ -24,13 +24,13 @@
 namespace
 {
 // Useful testing constants
-constexpr const uint64_t EXPECTED_SIZE = 9;
-constexpr const std::array<double, EXPECTED_SIZE> TEST_DATA{-3.5, -2.1, -1.1, 0.0, 4.7, 5.0,
+constexpr const uint64_t kExpectedSize = 9;
+constexpr const std::array<double, kExpectedSize> kTestData{-3.5, -2.1, -1.1, 0.0, 4.7, 5.0,
   6.7, 9.9, 11.0};
-constexpr const double EXPECTED_AVG = 3.4;
-constexpr const double EXPECTED_MIN = -3.5;
-constexpr const double EXPECTED_MAX = 11.0;
-constexpr const double EXPECTED_STD = 4.997999599839919955173;
+constexpr const double kExpectedAvg = 3.4;
+constexpr const double kExpectedMin = -3.5;
+constexpr const double kExpectedMax = 11.0;
+constexpr const double kExpectedStd = 4.997999599839919955173;
 }  // namespace
 
 /**
@@ -44,7 +44,7 @@ public:
     moving_average_statistics =
       std::make_unique<moving_average_statistics::MovingAverageStatistics>();
 
-    for (double d : TEST_DATA) {
+    for (double d : kTestData) {
       moving_average_statistics->addMeasurement(d);
       ASSERT_EQ(++expected_count, moving_average_statistics->getCount());
     }
@@ -74,19 +74,19 @@ TEST_F(MovingAverageStatisticsTestFixture, sanity) {
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_average) {
-  EXPECT_DOUBLE_EQ(moving_average_statistics->average(), EXPECTED_AVG);
+  EXPECT_DOUBLE_EQ(moving_average_statistics->average(), kExpectedAvg);
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_maximum) {
-  EXPECT_EQ(moving_average_statistics->max(), EXPECTED_MAX);
+  EXPECT_EQ(moving_average_statistics->max(), kExpectedMax);
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_minimum) {
-  EXPECT_EQ(moving_average_statistics->min(), EXPECTED_MIN);
+  EXPECT_EQ(moving_average_statistics->min(), kExpectedMin);
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_standard_deviation) {
-  EXPECT_DOUBLE_EQ(moving_average_statistics->standardDeviation(), EXPECTED_STD);
+  EXPECT_DOUBLE_EQ(moving_average_statistics->standardDeviation(), kExpectedStd);
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_average_empty) {
@@ -116,11 +116,11 @@ TEST_F(MovingAverageStatisticsTestFixture, test_count_empty) {
 
 TEST_F(MovingAverageStatisticsTestFixture, test_get_statistics) {
   auto result = moving_average_statistics->getStatistics();
-  EXPECT_DOUBLE_EQ(result.average, EXPECTED_AVG);
-  EXPECT_DOUBLE_EQ(result.min, EXPECTED_MIN);
-  EXPECT_DOUBLE_EQ(result.max, EXPECTED_MAX);
-  EXPECT_DOUBLE_EQ(result.standard_deviation, EXPECTED_STD);
-  EXPECT_DOUBLE_EQ(result.sample_count, EXPECTED_SIZE);
+  EXPECT_DOUBLE_EQ(result.average, kExpectedAvg);
+  EXPECT_DOUBLE_EQ(result.min, kExpectedMin);
+  EXPECT_DOUBLE_EQ(result.max, kExpectedMax);
+  EXPECT_DOUBLE_EQ(result.standard_deviation, kExpectedStd);
+  EXPECT_DOUBLE_EQ(result.sample_count, kExpectedSize);
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_get_statistics_int) {
@@ -129,10 +129,10 @@ TEST_F(MovingAverageStatisticsTestFixture, test_get_statistics_int) {
   auto data_int = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
   const double expected_average = 5.5;
-  const double expected_minimum = 1;
-  const double expected_maximum = 10;
-  const double expected_std = 2.8722813232690143;
-  const int expected_size = 10;
+  const double kExpectedMinimum = 1;
+  const double kExpectedMaximum = 10;
+  const double kExpectedStd = 2.8722813232690143;
+  const int kExpectedSize = 10;
 
   for (int d : data_int) {
     moving_average_statistics->addMeasurement(d);
@@ -140,10 +140,10 @@ TEST_F(MovingAverageStatisticsTestFixture, test_get_statistics_int) {
 
   auto result = moving_average_statistics->getStatistics();
   EXPECT_DOUBLE_EQ(result.average, expected_average);
-  EXPECT_DOUBLE_EQ(result.min, expected_minimum);
-  EXPECT_DOUBLE_EQ(result.max, expected_maximum);
-  EXPECT_DOUBLE_EQ(result.standard_deviation, expected_std);
-  EXPECT_DOUBLE_EQ(result.sample_count, expected_size);
+  EXPECT_DOUBLE_EQ(result.min, kExpectedMinimum);
+  EXPECT_DOUBLE_EQ(result.max, kExpectedMaximum);
+  EXPECT_DOUBLE_EQ(result.standard_deviation, kExpectedStd);
+  EXPECT_DOUBLE_EQ(result.sample_count, kExpectedSize);
 }
 
 TEST_F(MovingAverageStatisticsTestFixture, test_reset) {

--- a/system_metrics_collector/test/system_metrics_collector/test_constants.hpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_constants.hpp
@@ -20,13 +20,13 @@
  */
 namespace test_constants
 {
-constexpr const std::chrono::milliseconds TEST_DURATION{250};
-constexpr const std::chrono::milliseconds MEASURE_PERIOD{50};
-constexpr const std::chrono::milliseconds PUBLISH_PERIOD{80};
+constexpr const std::chrono::milliseconds kTestDuration{250};
+constexpr const std::chrono::milliseconds kMeasurePeriod{50};
+constexpr const std::chrono::milliseconds kPublishPeriod{80};
 
-constexpr const char PROC_SAMPLE_RESOLUTION_TEST[] =
+constexpr const char kProcSampleResolutionTest[] =
   "cpu  57211920 335926 18096939 2526329830 14818556 0 1072048 0 0 0\n";
-constexpr const std::array<const char *, 10> PROC_SAMPLES = {
+constexpr const std::array<const char *, 10> kProcSamples = {
   "cpu 22451232 118653 7348045 934943300 5378119 0 419114 0 0 0\n",
   "cpu 22451360 118653 7348080 934949227 5378120 0 419117 0 0 0\n",
   "cpu 24343452 61856 6484430 10645595 58695 0 683052 0 0 0\n",
@@ -38,19 +38,19 @@ constexpr const std::array<const char *, 10> PROC_SAMPLES = {
   "cpu 6093617 43419 1621953 9161570 48047 0 178792 0 0 0\n",
   "cpu 6134250 6371 1634411 675446 5285 0 233478 0 0 0\n"
 };
-constexpr const double CPU_ACTIVE_PROC_SAMPLE_0_1 = 2.7239908106334099;
+constexpr const double kCpuActiveProcSample_0_1 = 2.7239908106334099;
 
 
-constexpr const char EMPTY_SAMPLE[] = "";
-constexpr const char GARBAGE_SAMPLE[] = "this is garbage\n";
-constexpr const char INCOMPLETE_SAMPLE[] =
+constexpr const char kEmptySample[] = "";
+constexpr const char kGarbageSample[] = "this is garbage\n";
+constexpr const char kIncompleteSample[] =
   "MemTotal:       16302048 kB\n"
   "MemFree:          443300 kB\n";
-constexpr const char COMPLETE_SAMPLE[] =
+constexpr const char kCompleteSample[] =
   "MemTotal:       16302048 kB\n"
   "MemFree:          239124 kB\n"
   "MemAvailable:    9104952 kB\n";
-constexpr const char FULL_SAMPLE[] =
+constexpr const char kFullSample[] =
   "MemTotal:       16302048 kB\n"
   "MemFree:          239124 kB\n"
   "MemAvailable:    9104952 kB\n"
@@ -99,7 +99,7 @@ constexpr const char FULL_SAMPLE[] =
   "DirectMap4k:     3993192 kB\n"
   "DirectMap2M:    12660736 kB\n"
   "DirectMap1G:     1048576 kB";
-constexpr const double MEMORY_USED_PERCENTAGE = 44.148416198995363;
+constexpr const double kMemoryUsedPercentage = 44.148416198995363;
 }  // namespace test_constants
 
 #endif  // SYSTEM_METRICS_COLLECTOR__TEST_CONSTANTS_HPP_

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -38,14 +38,14 @@ using metrics_statistics_msgs::msg::StatisticDataPoint;
 using metrics_statistics_msgs::msg::StatisticDataType;
 using moving_average_statistics::StatisticData;
 using system_metrics_collector::processStatCpuLine;
-using test_constants::PROC_SAMPLES;
+using test_constants::kProcSamples;
 using test_utilities::computeCpuActivePercentage;
 
 namespace
 {
-constexpr const char TEST_NODE_NAME[] = "test_measure_linux_cpu";
-constexpr const char TEST_TOPIC[] = "test_cpu_measure_topic";
-constexpr const char TEST_METRIC_NAME[] = "system_cpu_percent_used";
+constexpr const char kTestNodeName[] = "test_measure_linux_cpu";
+constexpr const char kTestTopic[] = "test_cpu_measure_topic";
+constexpr const char kTestMetricName[] = "system_cpu_percent_used";
 }  // namespace
 
 
@@ -69,8 +69,8 @@ public:
 private:
   system_metrics_collector::ProcCpuData makeSingleMeasurement() override
   {
-    EXPECT_GT(PROC_SAMPLES.size(), measurement_index);
-    return processStatCpuLine(PROC_SAMPLES[measurement_index++]);
+    EXPECT_GT(kProcSamples.size(), measurement_index);
+    return processStatCpuLine(kProcSamples[measurement_index++]);
   }
 
   int measurement_index{0};
@@ -84,59 +84,59 @@ public:
   {
     auto callback = [this](MetricsMessage::UniquePtr msg) {this->MetricsMessageCallback(*msg);};
     subscription = create_subscription<MetricsMessage,
-        std::function<void(MetricsMessage::UniquePtr)>>(TEST_TOPIC, 10 /*history_depth*/, callback);
+        std::function<void(MetricsMessage::UniquePtr)>>(kTestTopic, 10 /*history_depth*/, callback);
 
     // tools for calculating expected statistics values
     moving_average_statistics::MovingAverageStatistics stats_calc;
     StatisticData data;
 
     // setting expected_stats[0]
-    // round 1 50 ms: PROC_SAMPLES[0] is collected
-    // round 1 80 ms: statistics derived from PROC_SAMPLES[N/A-0] is published
+    // round 1 50 ms: kProcSamples[0] is collected
+    // round 1 80 ms: statistics derived from kProcSamples[N/A-0] is published
     stats_calc.reset();
     data = StatisticData();
     StatisticDataToExpectedStatistics(data, expected_stats[0]);
 
     // setting expected_stats[1]
-    // round 1 100 ms: PROC_SAMPLES[1] is collected
-    // round 1 150 ms: PROC_SAMPLES[2] is collected
-    // round 1 160 ms: statistics derived from PROC_SAMPLES[0-1 & 1-2] is published
+    // round 1 100 ms: kProcSamples[1] is collected
+    // round 1 150 ms: kProcSamples[2] is collected
+    // round 1 160 ms: statistics derived from kProcSamples[0-1 & 1-2] is published
     stats_calc.reset();
-    stats_calc.addMeasurement(computeCpuActivePercentage(PROC_SAMPLES[0], PROC_SAMPLES[1]));
-    stats_calc.addMeasurement(computeCpuActivePercentage(PROC_SAMPLES[1], PROC_SAMPLES[2]));
+    stats_calc.addMeasurement(computeCpuActivePercentage(kProcSamples[0], kProcSamples[1]));
+    stats_calc.addMeasurement(computeCpuActivePercentage(kProcSamples[1], kProcSamples[2]));
     data = stats_calc.getStatistics();
     StatisticDataToExpectedStatistics(data, expected_stats[1]);
 
     // setting expected_stats[2]
-    // round 1 200 ms: PROC_SAMPLES[3] is collected
-    // round 1 240 ms: statistics derived from PROC_SAMPLES[2-3] is published
+    // round 1 200 ms: kProcSamples[3] is collected
+    // round 1 240 ms: statistics derived from kProcSamples[2-3] is published
     stats_calc.reset();
-    stats_calc.addMeasurement(computeCpuActivePercentage(PROC_SAMPLES[2], PROC_SAMPLES[3]));
+    stats_calc.addMeasurement(computeCpuActivePercentage(kProcSamples[2], kProcSamples[3]));
     data = stats_calc.getStatistics();
     StatisticDataToExpectedStatistics(data, expected_stats[2]);
 
     // setting expected_stats[3]
-    // round 2 50 ms: PROC_SAMPLES[5] is collected
-    // round 2 80 ms: statistics derived from PROC_SAMPLES[N/A-5] is published
+    // round 2 50 ms: kProcSamples[5] is collected
+    // round 2 80 ms: statistics derived from kProcSamples[N/A-5] is published
     stats_calc.reset();
     data = StatisticData();
     StatisticDataToExpectedStatistics(data, expected_stats[3]);
 
     // setting expected_stats[4]
-    // round 2 100 ms: PROC_SAMPLES[6] is collected
-    // round 2 150 ms: PROC_SAMPLES[7] is collected
-    // round 2 160 ms: statistics derived from PROC_SAMPLES[5-6 & 6-7] is published
+    // round 2 100 ms: kProcSamples[6] is collected
+    // round 2 150 ms: kProcSamples[7] is collected
+    // round 2 160 ms: statistics derived from kProcSamples[5-6 & 6-7] is published
     stats_calc.reset();
-    stats_calc.addMeasurement(computeCpuActivePercentage(PROC_SAMPLES[5], PROC_SAMPLES[6]));
-    stats_calc.addMeasurement(computeCpuActivePercentage(PROC_SAMPLES[6], PROC_SAMPLES[7]));
+    stats_calc.addMeasurement(computeCpuActivePercentage(kProcSamples[5], kProcSamples[6]));
+    stats_calc.addMeasurement(computeCpuActivePercentage(kProcSamples[6], kProcSamples[7]));
     data = stats_calc.getStatistics();
     StatisticDataToExpectedStatistics(data, expected_stats[4]);
 
     // setting expected_stats[5]
-    // round 2 200 ms: PROC_SAMPLES[8] is collected
-    // round 2 240 ms: statistics derived from PROC_SAMPLES[7-8] is published
+    // round 2 200 ms: kProcSamples[8] is collected
+    // round 2 240 ms: statistics derived from kProcSamples[7-8] is published
     stats_calc.reset();
-    stats_calc.addMeasurement(computeCpuActivePercentage(PROC_SAMPLES[7], PROC_SAMPLES[8]));
+    stats_calc.addMeasurement(computeCpuActivePercentage(kProcSamples[7], kProcSamples[8]));
     data = stats_calc.getStatistics();
     StatisticDataToExpectedStatistics(data, expected_stats[5]);
   }
@@ -164,8 +164,8 @@ private:
     ASSERT_GT(expected_stats.size(), times_received);
 
     // check source names
-    EXPECT_EQ(TEST_NODE_NAME, msg.measurement_source_name);
-    EXPECT_EQ(TEST_METRIC_NAME, msg.metrics_source);
+    EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
+    EXPECT_EQ(kTestMetricName, msg.metrics_source);
 
     // check measurements
     const ExpectedStatistics & expected_stat = expected_stats[times_received];
@@ -195,8 +195,8 @@ public:
   {
     rclcpp::init(0, nullptr);
 
-    test_measure_linux_cpu = std::make_shared<TestLinuxCpuMeasurementNode>(TEST_NODE_NAME,
-        test_constants::MEASURE_PERIOD, TEST_TOPIC, test_constants::PUBLISH_PERIOD);
+    test_measure_linux_cpu = std::make_shared<TestLinuxCpuMeasurementNode>(kTestNodeName,
+        test_constants::kMeasurePeriod, kTestTopic, test_constants::kPublishPeriod);
 
     ASSERT_FALSE(test_measure_linux_cpu->isStarted());
 
@@ -226,7 +226,7 @@ TEST_F(LinuxCpuMeasurementTestFixture, testManualMeasurement)
   ASSERT_TRUE(std::isnan(cpu_active_percentage));
   // second measurement compares current and cached
   cpu_active_percentage = test_measure_linux_cpu->periodicMeasurement();
-  ASSERT_DOUBLE_EQ(test_constants::CPU_ACTIVE_PROC_SAMPLE_0_1, cpu_active_percentage);
+  ASSERT_DOUBLE_EQ(test_constants::kCpuActiveProcSample_0_1, cpu_active_percentage);
 }
 
 TEST_F(LinuxCpuMeasurementTestFixture, testPublishMetricsMessage)
@@ -248,19 +248,19 @@ TEST_F(LinuxCpuMeasurementTestFixture, testPublishMetricsMessage)
   bool start_success = test_measure_linux_cpu->start();
   ASSERT_TRUE(start_success);
   ASSERT_TRUE(test_measure_linux_cpu->isStarted());
-  ex.spin_until_future_complete(dummy_future, test_constants::TEST_DURATION);
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(3, test_receive_measurements->getNumReceived());
   // expectation is:
-  // 50 ms: PROC_SAMPLES[0] is collected
-  // 80 ms: statistics derived from PROC_SAMPLES[N/A-0] is published. statistics are cleared
-  // 100 ms: PROC_SAMPLES[1] is collected
-  // 150 ms: PROC_SAMPLES[2] is collected
-  // 160 ms: statistics derived from PROC_SAMPLES[0-1 & 1-2] is published. statistics are cleared
-  // 200 ms: PROC_SAMPLES[3] is collected
-  // 240 ms: statistics derived from PROC_SAMPLES[2-3] is published. statistics are cleared
-  // 250 ms: PROC_SAMPLES[4] is collected. last getStatisticsResults() is of PROC_SAMPLES[3-4]
+  // 50 ms: kProcSamples[0] is collected
+  // 80 ms: statistics derived from kProcSamples[N/A-0] is published. statistics are cleared
+  // 100 ms: kProcSamples[1] is collected
+  // 150 ms: kProcSamples[2] is collected
+  // 160 ms: statistics derived from kProcSamples[0-1 & 1-2] is published. statistics are cleared
+  // 200 ms: kProcSamples[3] is collected
+  // 240 ms: statistics derived from kProcSamples[2-3] is published. statistics are cleared
+  // 250 ms: kProcSamples[4] is collected. last getStatisticsResults() is of kProcSamples[3-4]
   StatisticData data = test_measure_linux_cpu->getStatisticsResults();
-  double expected_cpu_active = computeCpuActivePercentage(PROC_SAMPLES[3], PROC_SAMPLES[4]);
+  double expected_cpu_active = computeCpuActivePercentage(kProcSamples[3], kProcSamples[4]);
   EXPECT_DOUBLE_EQ(expected_cpu_active, data.average);
   EXPECT_DOUBLE_EQ(expected_cpu_active, data.min);
   EXPECT_DOUBLE_EQ(expected_cpu_active, data.max);
@@ -273,7 +273,7 @@ TEST_F(LinuxCpuMeasurementTestFixture, testPublishMetricsMessage)
   bool stop_success = test_measure_linux_cpu->stop();
   ASSERT_TRUE(stop_success);
   ASSERT_FALSE(test_measure_linux_cpu->isStarted());
-  ex.spin_until_future_complete(dummy_future, test_constants::TEST_DURATION);
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(3, test_receive_measurements->getNumReceived());
   // expectation is:
   // upon calling stop, samples are cleared, so getStatisticsResults() would be NaNs
@@ -291,19 +291,19 @@ TEST_F(LinuxCpuMeasurementTestFixture, testPublishMetricsMessage)
   start_success = test_measure_linux_cpu->start();
   ASSERT_TRUE(start_success);
   ASSERT_TRUE(test_measure_linux_cpu->isStarted());
-  ex.spin_until_future_complete(dummy_future, test_constants::TEST_DURATION);
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(6, test_receive_measurements->getNumReceived());
   // expectation is:
-  // 50 ms: PROC_SAMPLES[5] is collected
-  // 80 ms: statistics derived from PROC_SAMPLES[N/A-5] is published. statistics are cleared
-  // 100 ms: PROC_SAMPLES[6] is collected
-  // 150 ms: PROC_SAMPLES[7] is collected
-  // 160 ms: statistics derived from PROC_SAMPLES[5-6 & 6-7] is published. statistics are cleared
-  // 200 ms: PROC_SAMPLES[8] is collected
-  // 240 ms: statistics derived from PROC_SAMPLES[7-8] is published. statistics are cleared
-  // 250 ms: PROC_SAMPLES[9] is collected. last getStatisticsResults() is of PROC_SAMPLES[8-9]
+  // 50 ms: kProcSamples[5] is collected
+  // 80 ms: statistics derived from kProcSamples[N/A-5] is published. statistics are cleared
+  // 100 ms: kProcSamples[6] is collected
+  // 150 ms: kProcSamples[7] is collected
+  // 160 ms: statistics derived from kProcSamples[5-6 & 6-7] is published. statistics are cleared
+  // 200 ms: kProcSamples[8] is collected
+  // 240 ms: statistics derived from kProcSamples[7-8] is published. statistics are cleared
+  // 250 ms: kProcSamples[9] is collected. last getStatisticsResults() is of kProcSamples[8-9]
   data = test_measure_linux_cpu->getStatisticsResults();
-  expected_cpu_active = computeCpuActivePercentage(PROC_SAMPLES[8], PROC_SAMPLES[9]);
+  expected_cpu_active = computeCpuActivePercentage(kProcSamples[8], kProcSamples[9]);
   EXPECT_DOUBLE_EQ(expected_cpu_active, data.average);
   EXPECT_DOUBLE_EQ(expected_cpu_active, data.min);
   EXPECT_DOUBLE_EQ(expected_cpu_active, data.max);

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -39,12 +39,12 @@ using system_metrics_collector::processMemInfoLines;
 
 namespace
 {
-constexpr const char TEST_NODE_NAME[] = "test_measure_linux_memory";
-constexpr const char TEST_TOPIC[] = "test_memory_measure_topic";
-constexpr const char TEST_METRIC_NAME[] = "system_memory_percent_used";
+constexpr const char kTestNodeName[] = "test_measure_linux_memory";
+constexpr const char kTestTopic[] = "test_memory_measure_topic";
+constexpr const char kTestMetricName[] = "system_memory_percent_used";
 
 constexpr const std::array<const char *, 10> SAMPLES = {
-  test_constants::FULL_SAMPLE,
+  test_constants::kFullSample,
 
   "MemTotal:       16304208 kB\n"
   "MemFree:          845168 kB\n"
@@ -131,8 +131,8 @@ public:
   {
     rclcpp::init(0, nullptr);
 
-    test_measure_linux_memory = std::make_shared<TestLinuxMemoryMeasurementNode>(TEST_NODE_NAME,
-        test_constants::MEASURE_PERIOD, TEST_TOPIC, test_constants::PUBLISH_PERIOD);
+    test_measure_linux_memory = std::make_shared<TestLinuxMemoryMeasurementNode>(kTestNodeName,
+        test_constants::kMeasurePeriod, kTestTopic, test_constants::kPublishPeriod);
 
     ASSERT_FALSE(test_measure_linux_memory->isStarted());
 
@@ -165,7 +165,7 @@ public:
   {
     auto callback = [this](MetricsMessage::UniquePtr msg) {this->MetricsMessageCallback(*msg);};
     subscription = create_subscription<MetricsMessage,
-        std::function<void(MetricsMessage::UniquePtr)>>(TEST_TOPIC, 10 /*history_depth*/, callback);
+        std::function<void(MetricsMessage::UniquePtr)>>(kTestTopic, 10 /*history_depth*/, callback);
 
     // tools for calculating expected statistics values
     moving_average_statistics::MovingAverageStatistics stats_calc;
@@ -247,8 +247,8 @@ private:
     ASSERT_GT(expected_stats.size(), times_received);
 
     // check source names
-    EXPECT_EQ(TEST_NODE_NAME, msg.measurement_source_name);
-    EXPECT_EQ(TEST_METRIC_NAME, msg.metrics_source);
+    EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
+    EXPECT_EQ(kTestMetricName, msg.metrics_source);
 
     // check measurements
     const ExpectedStatistics & expected_stat = expected_stats[times_received];
@@ -282,9 +282,9 @@ TEST_F(LinuxMemoryMeasurementTestFixture, testManualMeasurement) {
   double mem_used_percentage = test_measure_linux_memory->periodicMeasurement();
   ASSERT_TRUE(std::isnan(mem_used_percentage));
 
-  test_measure_linux_memory->setTestString(test_constants::FULL_SAMPLE);
+  test_measure_linux_memory->setTestString(test_constants::kFullSample);
   mem_used_percentage = test_measure_linux_memory->periodicMeasurement();
-  ASSERT_DOUBLE_EQ(test_constants::MEMORY_USED_PERCENTAGE, mem_used_percentage);
+  ASSERT_DOUBLE_EQ(test_constants::kMemoryUsedPercentage, mem_used_percentage);
 }
 
 TEST_F(LinuxMemoryMeasurementTestFixture, testPublishMetricsMessage)
@@ -306,7 +306,7 @@ TEST_F(LinuxMemoryMeasurementTestFixture, testPublishMetricsMessage)
   bool start_success = test_measure_linux_memory->start();
   ASSERT_TRUE(start_success);
   ASSERT_TRUE(test_measure_linux_memory->isStarted());
-  ex.spin_until_future_complete(dummy_future, test_constants::TEST_DURATION);
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(3, test_receive_measurements->getNumReceived());
   // expectation is:
   // 50 ms: SAMPLES[0] is collected
@@ -326,7 +326,7 @@ TEST_F(LinuxMemoryMeasurementTestFixture, testPublishMetricsMessage)
   bool stop_success = test_measure_linux_memory->stop();
   ASSERT_TRUE(stop_success);
   ASSERT_FALSE(test_measure_linux_memory->isStarted());
-  ex.spin_until_future_complete(dummy_future, test_constants::TEST_DURATION);
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(3, test_receive_measurements->getNumReceived());
   // expectation is:
   // upon calling stop, samples are cleared, so getStatisticsResults() would be NaNs
@@ -344,7 +344,7 @@ TEST_F(LinuxMemoryMeasurementTestFixture, testPublishMetricsMessage)
   start_success = test_measure_linux_memory->start();
   ASSERT_TRUE(start_success);
   ASSERT_TRUE(test_measure_linux_memory->isStarted());
-  ex.spin_until_future_complete(dummy_future, test_constants::TEST_DURATION);
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(6, test_receive_measurements->getNumReceived());
   // expectation is:
   // 50 ms: SAMPLES[5] is collected

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -26,7 +26,7 @@
 
 namespace
 {
-constexpr const char TEST_STATM_LINE[] = "2084389 308110 7390 1 0 366785 0\n";
+constexpr const char kTestStatmLine[] = "2084389 308110 7390 1 0 366785 0\n";
 }
 
 class TestLinuxProcessMemoryMeasurementNode : public system_metrics_collector::
@@ -86,11 +86,11 @@ protected:
 
 TEST(TestLinuxProcessMemoryMeasurement, testGetProcessUsedMemory) {
   EXPECT_THROW(system_metrics_collector::getProcessUsedMemory(
-      test_constants::GARBAGE_SAMPLE), std::ifstream::failure);
+      test_constants::kGarbageSample), std::ifstream::failure);
   EXPECT_THROW(system_metrics_collector::getProcessUsedMemory(
-      test_constants::EMPTY_SAMPLE), std::ifstream::failure);
+      test_constants::kEmptySample), std::ifstream::failure);
 
-  const auto ret = system_metrics_collector::getProcessUsedMemory(TEST_STATM_LINE);
+  const auto ret = system_metrics_collector::getProcessUsedMemory(kTestStatmLine);
   EXPECT_EQ(2084389, ret);
 }
 

--- a/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
@@ -31,13 +31,13 @@ using system_metrics_collector::MetricsMessagePublisher;
 
 namespace
 {
-constexpr const char TEST_NODE_NAME[] = "test_publisher";
-constexpr const char TEST_MEASUREMENT_TYPE[] = "test_measurement";
+constexpr const char kTestNodeName[] = "test_publisher";
+constexpr const char kTestMeasurementType[] = "test_measurement";
 }  // namespace
 
 TEST(MetricsMessagePublisherTest, test_generate_message) {
   rclcpp::init(0, nullptr);
-  auto node = std::make_shared<rclcpp::Node>(TEST_NODE_NAME);
+  auto node = std::make_shared<rclcpp::Node>(kTestNodeName);
   rclcpp::Time time1 = node->now();
   rclcpp::Time time2 = node->now();
 
@@ -51,10 +51,10 @@ TEST(MetricsMessagePublisherTest, test_generate_message) {
   data.sample_count = dist(gen);
 
   MetricsMessage msg = MetricsMessagePublisher::generateStatisticMessage(
-    TEST_NODE_NAME, TEST_MEASUREMENT_TYPE, time1, time2, data);
+    kTestNodeName, kTestMeasurementType, time1, time2, data);
 
-  EXPECT_EQ(TEST_NODE_NAME, msg.measurement_source_name);
-  EXPECT_EQ(TEST_MEASUREMENT_TYPE, msg.metrics_source);
+  EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
+  EXPECT_EQ(kTestMeasurementType, msg.metrics_source);
   EXPECT_EQ(time1, msg.window_start);
   EXPECT_EQ(time2, msg.window_stop);
 

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -30,9 +30,9 @@
 
 namespace
 {
-constexpr const char TEST_NODE_NAME[] = "test_periodic_node";
-constexpr const char TEST_TOPIC[] = "test_topic";
-constexpr const char TEST_METRIC_NAME[] = "test_metric_name";
+constexpr const char kTestNodeName[] = "test_periodic_node";
+constexpr const char kTestTopic[] = "test_topic";
+constexpr const char kTestMetricname[] = "test_metric_name";
 }  // namespace
 
 /**
@@ -78,7 +78,7 @@ private:
 
   std::string getMetricName() const
   {
-    return TEST_METRIC_NAME;
+    return kTestMetricname;
   }
 
   std::atomic<int> times_measured{0};
@@ -95,8 +95,8 @@ public:
   {
     rclcpp::init(0, nullptr);
 
-    test_periodic_measurer = std::make_shared<TestPeriodicMeasurementNode>(TEST_NODE_NAME,
-        test_constants::MEASURE_PERIOD, TEST_TOPIC, DONT_PUBLISH_DURING_TEST);
+    test_periodic_measurer = std::make_shared<TestPeriodicMeasurementNode>(kTestNodeName,
+        test_constants::kMeasurePeriod, kTestTopic, DONT_PUBLISH_DURING_TEST);
 
     ASSERT_FALSE(test_periodic_measurer->isStarted());
 
@@ -121,7 +121,7 @@ protected:
   // so this is defining the publish period to be something amply larger than the test duration
   // itself
   static constexpr std::chrono::milliseconds DONT_PUBLISH_DURING_TEST = 2 *
-    test_constants::TEST_DURATION;
+    test_constants::kTestDuration;
   std::shared_ptr<TestPeriodicMeasurementNode> test_periodic_measurer;
 };
 
@@ -148,16 +148,16 @@ TEST_F(PeriodicMeasurementTestFixure, test_start_and_stop) {
 
   rclcpp::executors::SingleThreadedExecutor ex;
   ex.add_node(test_periodic_measurer);
-  ex.spin_until_future_complete(dummy_future, test_constants::TEST_DURATION);
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
 
   moving_average_statistics::StatisticData data = test_periodic_measurer->getStatisticsResults();
   ASSERT_EQ(3, data.average);
   ASSERT_EQ(1, data.min);
-  ASSERT_EQ(test_constants::TEST_DURATION.count() / test_constants::MEASURE_PERIOD.count(),
+  ASSERT_EQ(test_constants::kTestDuration.count() / test_constants::kMeasurePeriod.count(),
     data.max);
   ASSERT_FALSE(std::isnan(data.standard_deviation));
   ASSERT_EQ(
-    test_constants::TEST_DURATION.count() / test_constants::MEASURE_PERIOD.count(),
+    test_constants::kTestDuration.count() / test_constants::kMeasurePeriod.count(),
     data.sample_count);
 
   const bool stop_success = test_periodic_measurer->stop();
@@ -166,7 +166,7 @@ TEST_F(PeriodicMeasurementTestFixure, test_start_and_stop) {
 
   int times_published = test_periodic_measurer->getNumPublished();
   ASSERT_EQ(
-    test_constants::TEST_DURATION.count() / DONT_PUBLISH_DURING_TEST.count(), times_published);
+    test_constants::kTestDuration.count() / DONT_PUBLISH_DURING_TEST.count(), times_published);
 }
 
 int main(int argc, char ** argv)

--- a/system_metrics_collector/test/system_metrics_collector/test_utilities.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_utilities.cpp
@@ -70,7 +70,7 @@ TEST(UtilitiesTest, testEmptyProcCpuData)
 {
   system_metrics_collector::ProcCpuData empty;
 
-  ASSERT_EQ(system_metrics_collector::ProcCpuData::EMPTY_LABEL, empty.cpu_label);
+  ASSERT_EQ(system_metrics_collector::ProcCpuData::kEmptyLabel, empty.cpu_label);
 
   for (int i = 0; i < static_cast<int>(system_metrics_collector::ProcCpuStates::kNumProcCpuStates);
     i++)

--- a/system_metrics_collector/test/system_metrics_collector/test_utilities.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_utilities.cpp
@@ -27,7 +27,7 @@
 
 TEST(UtilitiesTest, testParseProcStatLine)
 {
-  auto parsed_data = system_metrics_collector::processStatCpuLine(test_constants::PROC_SAMPLES[0]);
+  auto parsed_data = system_metrics_collector::processStatCpuLine(test_constants::kProcSamples[0]);
 
   ASSERT_EQ("cpu", parsed_data.cpu_label);
   ASSERT_EQ(22451232, parsed_data.times[0]);
@@ -48,7 +48,7 @@ TEST(UtilitiesTest, testParseProcStatLine)
 TEST(UtilitiesTest, testParseProcStatLine2)
 {
   auto parsed_data = system_metrics_collector::processStatCpuLine(
-    test_constants::PROC_SAMPLE_RESOLUTION_TEST);
+    test_constants::kProcSampleResolutionTest);
 
   ASSERT_EQ("cpu", parsed_data.cpu_label);
   ASSERT_EQ(57211920, parsed_data.times[0]);
@@ -81,27 +81,27 @@ TEST(UtilitiesTest, testEmptyProcCpuData)
 
 TEST(UtilitiesTest, testCalculateCpuActivePercentage)
 {
-  auto p = test_utilities::computeCpuActivePercentage(test_constants::PROC_SAMPLES[0],
-      test_constants::PROC_SAMPLES[1]);
-  ASSERT_DOUBLE_EQ(test_constants::CPU_ACTIVE_PROC_SAMPLE_0_1, p);
+  auto p = test_utilities::computeCpuActivePercentage(test_constants::kProcSamples[0],
+      test_constants::kProcSamples[1]);
+  ASSERT_DOUBLE_EQ(test_constants::kCpuActiveProcSample_0_1, p);
 }
 
 TEST(UtilitiesTest, testProcMemInfoLines)
 {
-  auto d = system_metrics_collector::processMemInfoLines(test_constants::EMPTY_SAMPLE);
+  auto d = system_metrics_collector::processMemInfoLines(test_constants::kEmptySample);
   ASSERT_TRUE(std::isnan(d));
 
-  d = system_metrics_collector::processMemInfoLines(test_constants::GARBAGE_SAMPLE);
+  d = system_metrics_collector::processMemInfoLines(test_constants::kGarbageSample);
   ASSERT_TRUE(std::isnan(d));
 
-  d = system_metrics_collector::processMemInfoLines(test_constants::INCOMPLETE_SAMPLE);
+  d = system_metrics_collector::processMemInfoLines(test_constants::kIncompleteSample);
   ASSERT_TRUE(std::isnan(d));
 
-  d = system_metrics_collector::processMemInfoLines(test_constants::COMPLETE_SAMPLE);
-  ASSERT_DOUBLE_EQ(test_constants::MEMORY_USED_PERCENTAGE, d);
+  d = system_metrics_collector::processMemInfoLines(test_constants::kCompleteSample);
+  ASSERT_DOUBLE_EQ(test_constants::kMemoryUsedPercentage, d);
 
-  d = system_metrics_collector::processMemInfoLines(test_constants::FULL_SAMPLE);
-  ASSERT_DOUBLE_EQ(test_constants::MEMORY_USED_PERCENTAGE, d);
+  d = system_metrics_collector::processMemInfoLines(test_constants::kFullSample);
+  ASSERT_DOUBLE_EQ(test_constants::kMemoryUsedPercentage, d);
 }
 
 TEST(UtilitiesTest, testReadInvalidFile)


### PR DESCRIPTION
* Update style guide constants to follow ROS2 (Google) naming convention
* Use curly initializers where applicable