### PR TITLE
Fix linting issues

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -39,6 +39,7 @@ constexpr const char kMetricName[] = "_memory_percent_used";
  */
 double GetSystemTotalMemory()
 {
+  // the following needs the struct keyword because sysinfo is also a function name
   struct sysinfo si {};
   const auto success = sysinfo(&si);
   return success == -1 ? std::nan("") : static_cast<double>(si.totalram);

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -39,7 +39,7 @@ constexpr const char kMetricName[] = "_memory_percent_used";
  */
 double GetSystemTotalMemory()
 {
-  struct sysinfo si;
+  struct sysinfo si {};
   const auto success = sysinfo(&si);
   return success == -1 ? std::nan("") : static_cast<double>(si.totalram);
 }
@@ -66,10 +66,10 @@ double LinuxProcessMemoryMeasurementNode::PeriodicMeasurement()
   double p_mem;
   try {
     p_mem = static_cast<double>(GetProcessUsedMemory(statm_line));
-  } catch (std::ifstream::failure e) {
+  } catch (const std::ifstream::failure & e) {
     RCLCPP_ERROR(
       this->get_logger(), "caught %s, failed to GetProcessUsedMemory from line %s",
-      e.what(), file_to_read_);
+      e.what(), file_to_read_.c_str());
     return std::nan("");
   }
   const auto total_mem = GetSystemTotalMemory();

--- a/system_metrics_collector/src/system_metrics_collector/utilities.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/utilities.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <time.h>
 #include <unistd.h>
 
 #include <chrono>
 #include <cmath>
+#include <ctime>
 #include <fstream>
 #include <limits>
 #include <sstream>

--- a/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
@@ -27,7 +27,7 @@ class TestCollector : public system_metrics_collector::Collector
 {
 public:
   TestCollector() = default;
-  virtual ~TestCollector() = default;
+  ~TestCollector() override = default;
   bool SetupStart() override
   {
     return true;

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -57,7 +57,7 @@ public:
     const std::chrono::milliseconds publish_period)
   : LinuxCpuMeasurementNode(name, measurement_period, publishing_topic, publish_period) {}
 
-  virtual ~TestLinuxCpuMeasurementNode() = default;
+  ~TestLinuxCpuMeasurementNode() override = default;
 
   // make this private method public for unit testing purposes
   double PeriodicMeasurement() override

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -97,7 +97,7 @@ public:
   : LinuxMemoryMeasurementNode(name, measurement_period, publishing_topic, publish_period),
     measurement_index_(0) {}
 
-  virtual ~TestLinuxMemoryMeasurementNode() = default;
+  ~TestLinuxMemoryMeasurementNode() override = default;
 
   void SetTestString(const std::string & test_string)
   {

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -47,7 +47,7 @@ public:
     const std::string & publishing_topic,
     const std::chrono::milliseconds publish_period)
   : PeriodicMeasurementNode(name, measurement_period, publishing_topic, publish_period) {}
-  virtual ~TestPeriodicMeasurementNode() = default;
+  ~TestPeriodicMeasurementNode() override = default;
 
   int GetNumPublished() const
   {
@@ -76,7 +76,7 @@ private:
     ++times_published_;
   }
 
-  std::string GetMetricName() const
+  std::string GetMetricName() const override
   {
     return kTestMetricname;
   }


### PR DESCRIPTION
Fix linting issues found by `clang-tidy` 6.0.