### PR TITLE
Add process CPU usage measurement node

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(system_metrics_collector SHARED
   src/system_metrics_collector/collector.cpp
   src/system_metrics_collector/linux_cpu_measurement_node.cpp
   src/system_metrics_collector/linux_memory_measurement_node.cpp
+  src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
   src/system_metrics_collector/linux_process_memory_measurement_node.cpp
   src/system_metrics_collector/periodic_measurement_node.cpp
   src/system_metrics_collector/proc_cpu_data.cpp
@@ -79,6 +80,11 @@ if(BUILD_TESTING)
           test/system_metrics_collector/test_linux_memory_measurement.cpp)
   target_link_libraries(test_linux_memory_measurement_node system_metrics_collector)
   ament_target_dependencies(test_linux_memory_measurement_node metrics_statistics_msgs rclcpp)
+
+  ament_add_gtest(test_linux_process_cpu_measurement_node
+          test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp)
+  target_link_libraries(test_linux_process_cpu_measurement_node system_metrics_collector)
+  ament_target_dependencies(test_linux_process_cpu_measurement_node metrics_statistics_msgs rclcpp)
 
   ament_add_gtest(test_linux_process_memory_measurement_node
           test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp)

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -57,13 +57,18 @@ bool LinuxProcessCpuMeasurementNode::SetupStart()
 
 double LinuxProcessCpuMeasurementNode::PeriodicMeasurement()
 {
-  const auto current_measurement = MeasurePidCpuTime();
+  const auto current_measurement = MakeSingleMeasurement();
 
   const auto cpu_percentage = ComputePidCpuActivePercentage(last_measurement_, current_measurement);
 
   last_measurement_ = current_measurement;
 
   return cpu_percentage;
+}
+
+ProcPidCpuData LinuxProcessCpuMeasurementNode::MakeSingleMeasurement()
+{
+  return MeasurePidCpuTime();
 }
 
 std::string LinuxProcessCpuMeasurementNode::GetMetricName() const

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -1,0 +1,74 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "linux_process_cpu_measurement_node.hpp"
+
+#include <sys/sysinfo.h>
+#include <sys/types.h>
+
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <tuple>
+
+#include "rcutils/logging_macros.h"
+
+namespace
+{
+
+constexpr const char kProcStatFile[] = "/proc/stat";
+constexpr const char kProc[] = "/proc/";
+constexpr const char kStat[] = "/stat";
+constexpr const char kMetricName[] = "_cpu_percent_used";
+
+}  // namespace
+
+namespace system_metrics_collector
+{
+
+LinuxProcessCpuMeasurementNode::LinuxProcessCpuMeasurementNode(
+  const std::string & name,
+  const std::chrono::milliseconds measurement_period,
+  const std::string & topic,
+  const std::chrono::milliseconds publish_period)
+: PeriodicMeasurementNode(name, measurement_period, topic, publish_period),
+  metric_name_(std::to_string(GetPid()) + kMetricName)
+{
+}
+
+bool LinuxProcessCpuMeasurementNode::SetupStart()
+{
+  last_measurement_ = ProcPidCpuData();
+  return PeriodicMeasurementNode::SetupStart();
+}
+
+double LinuxProcessCpuMeasurementNode::PeriodicMeasurement()
+{
+  const ProcPidCpuData current_measurement = MeasurePidCpuTime();
+
+  const auto cpu_percentage = ComputePidCpuActivePercentage(last_measurement_, current_measurement);
+
+  last_measurement_ = current_measurement;
+
+  return cpu_percentage;
+}
+
+std::string LinuxProcessCpuMeasurementNode::GetMetricName() const
+{
+  return metric_name_;
+}
+
+}   // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -57,7 +57,7 @@ bool LinuxProcessCpuMeasurementNode::SetupStart()
 
 double LinuxProcessCpuMeasurementNode::PeriodicMeasurement()
 {
-  const ProcPidCpuData current_measurement = MeasurePidCpuTime();
+  const auto current_measurement = MeasurePidCpuTime();
 
   const auto cpu_percentage = ComputePidCpuActivePercentage(last_measurement_, current_measurement);
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -1,0 +1,94 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SYSTEM_METRICS_COLLECTOR__LINUX_PROCESS_CPU_MEASUREMENT_NODE_HPP_
+#define SYSTEM_METRICS_COLLECTOR__LINUX_PROCESS_CPU_MEASUREMENT_NODE_HPP_
+
+#include <chrono>
+#include <cmath>
+#include <string>
+#include <tuple>
+
+#include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
+#include "../../src/system_metrics_collector/proc_cpu_data.hpp"
+#include "../../src/system_metrics_collector/utilities.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/logging_macros.h"
+
+
+namespace system_metrics_collector
+{
+
+/**
+ * Measures the CPU percentage used by the process.
+ */
+class LinuxProcessCpuMeasurementNode : public PeriodicMeasurementNode
+{
+public:
+  /**
+   * Constructs a LinuxProcessCpuMeasurementNode.
+   *
+   * @param name the name of this node
+   * @param measurement_period the period of this node, used to read measurements
+   * @param topic the topic name used for publishing
+   * @param publish_period the period at which metrics are published.
+   */
+  LinuxProcessCpuMeasurementNode(
+    const std::string & name,
+    const std::chrono::milliseconds measurement_period,
+    const std::string & topic,
+    const std::chrono::milliseconds publish_period);
+
+protected:
+  /**
+   * Creates ROS2 timers and a publisher for periodically triggering measurements and publishing
+   * MetricsMessages.
+   * This function needs to be overridden because this class needs to also reset last_measurement_
+   * on every start or restart in addition to what is done by PeriodicMeasurementNode.
+   *
+   * @return if setup was successful
+   */
+  bool SetupStart() override;
+
+  /**
+   * Performs a periodic measurement and calculation of the percentage of CPU this process used.
+   * This obtains measurements from clock_gettime() to obtain process-specific and system-wide CPU
+   * used.
+   *
+   * @return percentage of CPU this process used
+   */
+  double PeriodicMeasurement() override;
+
+  /**
+   * Returns the name to use for this metric.
+   *
+   * @return a string of the name for this measured metric
+   */
+  std::string GetMetricName() const override;
+
+private:
+  /**
+   * The pid of this process.
+   */
+  const std::string metric_name_;
+  /**
+   * The cached processa and system measurements used in order to perform the CPU active percentage.
+   */
+  ProcPidCpuData last_measurement_;
+};
+
+}  // namespace system_metrics_collector
+
+#endif  // SYSTEM_METRICS_COLLECTOR__LINUX_PROCESS_CPU_MEASUREMENT_NODE_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -91,7 +91,7 @@ private:
    */
   const std::string metric_name_;
   /**
-   * The cached processa and system measurements used in order to perform the CPU active percentage.
+   * The cached process and system measurements used in order to perform the CPU active percentage.
    */
   ProcPidCpuData last_measurement_;
 };

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -20,9 +20,9 @@
 #include <string>
 #include <tuple>
 
-#include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
-#include "../../src/system_metrics_collector/proc_cpu_data.hpp"
-#include "../../src/system_metrics_collector/utilities.hpp"
+#include "periodic_measurement_node.hpp"
+#include "proc_cpu_data.hpp"
+#include "utilities.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/logging_macros.h"

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -64,8 +64,8 @@ protected:
 
   /**
    * Performs a periodic measurement and calculation of the percentage of CPU this process used.
-   * This obtains measurements from clock_gettime() to obtain process-specific and system-wide CPU
-   * used.
+   * This obtains measurements from MakeSingleMeasurement() to obtain process-specific
+   * and system-wide CPU used.
    *
    * @return percentage of CPU this process used
    */
@@ -79,6 +79,13 @@ protected:
   std::string GetMetricName() const override;
 
 private:
+  /**
+   * Performs a single measurement of CPU data by using clock_gettime().
+   *
+   * @return ProcCpuData the measurement made
+   */
+  virtual system_metrics_collector::ProcPidCpuData MakeSingleMeasurement();
+
   /**
    * The pid of this process.
    */

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -34,6 +34,17 @@ constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
 constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
 }  // namespace
 
+void set_node_to_debug(
+  const system_metrics_collector::PeriodicMeasurementNode * node,
+  const char * node_type)
+{
+  const auto r = rcutils_logging_set_logger_level(node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+  if (r != 0) {
+    RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the %s node: %s\n", node_type,
+      rcutils_get_error_string().str);
+  }
+}
+
 /**
  * This is current a "test" main in order to manually test the measurement nodes.
  *
@@ -62,14 +73,14 @@ int main(int argc, char ** argv)
     std::make_shared<system_metrics_collector::LinuxProcessCpuMeasurementNode>(
     "linuxProcessCpuCollector",
     kDefaultCollectPeriod,
-    "not_publishing_yet",
+    kStatisticsTopicName,
     kDefaultPublishPeriod);
 
   const auto process_mem_node =
     std::make_shared<system_metrics_collector::LinuxProcessMemoryMeasurementNode>(
     "linuxProcessMemoryCollector",
     kDefaultCollectPeriod,
-    "not_publishing_yet",
+    kStatisticsTopicName,
     kDefaultPublishPeriod);
 
   rclcpp::executors::MultiThreadedExecutor ex;
@@ -78,42 +89,10 @@ int main(int argc, char ** argv)
   process_cpu_node->Start();
   process_mem_node->Start();
 
-  {
-    const auto r =
-      rcutils_logging_set_logger_level(cpu_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-    if (r != 0) {
-      RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the cpu node: %s\n",
-        rcutils_get_error_string().str);
-    }
-  }
-  {
-    const auto r =
-      rcutils_logging_set_logger_level(mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-    if (r != 0) {
-      RCUTILS_LOG_ERROR_NAMED("main", "Unable to set debug logging for the memory node: %s\n",
-        rcutils_get_error_string().str);
-    }
-  }
-  {
-    const auto r = rcutils_logging_set_logger_level(
-      process_cpu_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-    if (r != 0) {
-      RCUTILS_LOG_ERROR_NAMED("main",
-        "Unable to set debug logging for the process cpu node: %s\n",
-        rcutils_get_error_string().str);
-    }
-  }
-  {
-    const auto r = rcutils_logging_set_logger_level(
-      process_mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-    if (r != 0) {
-      RCUTILS_LOG_ERROR_NAMED("main",
-        "Unable to set debug logging for the process memory node: %s\n",
-        rcutils_get_error_string().str);
-    }
-  }
+  set_node_to_debug(cpu_node.get(), "cpu");
+  set_node_to_debug(mem_node.get(), "memory");
+  set_node_to_debug(process_cpu_node.get(), "process cpu");
+  set_node_to_debug(process_mem_node.get(), "process memory");
 
   ex.add_node(cpu_node);
   ex.add_node(mem_node);

--- a/system_metrics_collector/test/system_metrics_collector/test_constants.hpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_constants.hpp
@@ -46,9 +46,17 @@ constexpr const std::array<const char *, 10> kProcSamples = {
 };
 constexpr const double kCpuActiveProcSample_0_1 = 2.7239908106334099;
 
-constexpr const std::array<system_metrics_collector::ProcPidCpuData, 2> kProcPidSamples = {
+constexpr const std::array<system_metrics_collector::ProcPidCpuData, 10> kProcPidSamples = {
   system_metrics_collector::ProcPidCpuData{7348045, 22451232},
-  system_metrics_collector::ProcPidCpuData{7348080, 22451360}
+  system_metrics_collector::ProcPidCpuData{7348080, 22451360},
+  system_metrics_collector::ProcPidCpuData{7348100, 22451471},
+  system_metrics_collector::ProcPidCpuData{7348112, 22451591},
+  system_metrics_collector::ProcPidCpuData{7348240, 22452023},
+  system_metrics_collector::ProcPidCpuData{7348245, 22452730},
+  system_metrics_collector::ProcPidCpuData{7348258, 22452824},
+  system_metrics_collector::ProcPidCpuData{7348390, 22452902},
+  system_metrics_collector::ProcPidCpuData{7348422, 22453047},
+  system_metrics_collector::ProcPidCpuData{7348423, 22454600}
 };
 constexpr const double kCpuActiveProcPidSample_0_1 = 27.34375;
 

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -1,0 +1,222 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <fstream>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+
+#include "metrics_statistics_msgs/msg/metrics_message.hpp"
+#include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
+
+#include "../../src/system_metrics_collector/linux_process_cpu_measurement_node.hpp"
+#include "../../src/system_metrics_collector/proc_cpu_data.hpp"
+#include "../../src/system_metrics_collector/utilities.hpp"
+
+#include "test_constants.hpp"
+#include "test_utilities.hpp"
+
+using metrics_statistics_msgs::msg::MetricsMessage;
+using metrics_statistics_msgs::msg::StatisticDataPoint;
+using moving_average_statistics::StatisticData;
+
+namespace
+{
+constexpr const char kTestNodeName[] = "test_measure_linux_process_cpu";
+constexpr const char kTestTopic[] = "test_process_cpu_measure_topic";
+}
+
+class TestLinuxProcessCpuMeasurementNode : public system_metrics_collector::
+  LinuxProcessCpuMeasurementNode
+{
+public:
+  TestLinuxProcessCpuMeasurementNode(
+    const std::string & name,
+    const std::chrono::milliseconds measurement_period,
+    const std::string & topic,
+    const std::chrono::milliseconds publish_period)
+  : LinuxProcessCpuMeasurementNode(name, measurement_period, topic, publish_period) {}
+
+  double PeriodicMeasurement() override
+  {
+    LinuxProcessCpuMeasurementNode::PeriodicMeasurement();
+  }
+
+  std::string GetMetricName() const override
+  {
+    return LinuxProcessCpuMeasurementNode::GetMetricName();
+  }
+};
+
+class TestReceiveProcessCpuMeasurementNode : public rclcpp::Node
+{
+public:
+  explicit TestReceiveProcessCpuMeasurementNode(
+    const std::string & name,
+    const std::string & metric)
+  : rclcpp::Node(name), expected_metric_name_(metric), times_received_(0)
+  {
+    auto callback = [this](MetricsMessage::UniquePtr msg) {this->MetricsMessageCallback(*msg);};
+    subscription_ = create_subscription<MetricsMessage,
+        std::function<void(MetricsMessage::UniquePtr)>>(kTestTopic, 10 /*history_depth*/, callback);
+  }
+
+  int GetNumReceived() const
+  {
+    return times_received_;
+  }
+
+private:
+  void MetricsMessageCallback(const MetricsMessage & msg) const
+  {
+    ASSERT_GT(6, times_received_);
+
+    // check source names
+    EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
+    EXPECT_EQ(expected_metric_name_, msg.metrics_source);
+
+    // check measurements
+    EXPECT_EQ(5, msg.statistics.size());
+
+    for (const StatisticDataPoint & stat : msg.statistics) {
+      EXPECT_GT(stat.data_type, 0);
+      if (!std::isnan(stat.data)) {
+        EXPECT_GE(stat.data, 0.0);
+      }
+    }
+
+    ++times_received_;
+  }
+
+  rclcpp::Subscription<MetricsMessage>::SharedPtr subscription_;
+  std::string expected_metric_name_;
+  mutable int times_received_;
+};
+
+class LinuxProcessCpuMeasurementTestFixture : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    using namespace std::chrono_literals;
+
+    rclcpp::init(0, nullptr);
+
+    test_node_ = std::make_shared<TestLinuxProcessCpuMeasurementNode>(kTestNodeName,
+        test_constants::kMeasurePeriod, kTestTopic, test_constants::kPublishPeriod);
+
+    ASSERT_FALSE(test_node_->IsStarted());
+
+    const moving_average_statistics::StatisticData data = test_node_->GetStatisticsResults();
+    ASSERT_TRUE(std::isnan(data.average));
+    ASSERT_TRUE(std::isnan(data.min));
+    ASSERT_TRUE(std::isnan(data.max));
+    ASSERT_TRUE(std::isnan(data.standard_deviation));
+    ASSERT_EQ(0, data.sample_count);
+  }
+
+  void TearDown() override
+  {
+    test_node_->Stop();
+    ASSERT_FALSE(test_node_->IsStarted());
+    test_node_.reset();
+    rclcpp::shutdown();
+  }
+
+protected:
+  std::shared_ptr<TestLinuxProcessCpuMeasurementNode> test_node_;
+};
+
+TEST_F(LinuxProcessCpuMeasurementTestFixture, TestGetMetricName) {
+  const int pid = system_metrics_collector::GetPid();
+  ASSERT_EQ(std::to_string(pid) + "_cpu_percent_used", test_node_->GetMetricName());
+}
+
+TEST_F(LinuxProcessCpuMeasurementTestFixture, TestManualMeasurement)
+{
+  // first measurement caches
+  double cpu_active_percentage = test_node_->PeriodicMeasurement();
+  ASSERT_TRUE(std::isnan(cpu_active_percentage));
+  // second measurement compares current and cached
+  cpu_active_percentage = test_node_->PeriodicMeasurement();
+  ASSERT_GE(cpu_active_percentage, 0.0);
+}
+
+TEST_F(LinuxProcessCpuMeasurementTestFixture, TestPublishMetricsMessage)
+{
+  ASSERT_NE(test_node_, nullptr);
+  ASSERT_FALSE(test_node_->IsStarted());
+
+  auto test_receive_measurements = std::make_shared<TestReceiveProcessCpuMeasurementNode>(
+    "test_receive_measurements", test_node_->GetMetricName());
+  std::promise<bool> empty_promise;
+  std::shared_future<bool> dummy_future = empty_promise.get_future();
+  rclcpp::executors::SingleThreadedExecutor ex;
+  ex.add_node(test_node_);
+  ex.add_node(test_receive_measurements);
+
+  //
+  // spin the node with it started
+  //
+  bool start_success = test_node_->Start();
+  ASSERT_TRUE(start_success);
+  ASSERT_TRUE(test_node_->IsStarted());
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
+  EXPECT_EQ(3, test_receive_measurements->GetNumReceived());
+
+  StatisticData data = test_node_->GetStatisticsResults();
+  EXPECT_GE(data.average, 0.0);
+  EXPECT_GE(data.min, 0.0);
+  EXPECT_GE(data.max, 0.0);
+  EXPECT_GE(data.standard_deviation, 0.0);
+  EXPECT_EQ(1, data.sample_count);
+
+  //
+  // spin the node with it stopped
+  //
+  bool stop_success = test_node_->Stop();
+  ASSERT_TRUE(stop_success);
+  ASSERT_FALSE(test_node_->IsStarted());
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
+  EXPECT_EQ(3, test_receive_measurements->GetNumReceived());
+  // expectation is:
+  // upon calling stop, samples are cleared, so GetStatisticsResults() would be NaNs
+  // no MetricsMessages are published
+  data = test_node_->GetStatisticsResults();
+  EXPECT_TRUE(std::isnan(data.average));
+  EXPECT_TRUE(std::isnan(data.min));
+  EXPECT_TRUE(std::isnan(data.max));
+  EXPECT_TRUE(std::isnan(data.standard_deviation));
+  EXPECT_EQ(0, data.sample_count);
+
+  //
+  // spin the node with it restarted
+  //
+  start_success = test_node_->Start();
+  ASSERT_TRUE(start_success);
+  ASSERT_TRUE(test_node_->IsStarted());
+  ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
+  EXPECT_EQ(6, test_receive_measurements->GetNumReceived());
+
+  data = test_node_->GetStatisticsResults();
+  EXPECT_GE(data.average, 0.0);
+  EXPECT_GE(data.min, 0.0);
+  EXPECT_GE(data.max, 0.0);
+  EXPECT_GE(data.standard_deviation, 0.0);
+  EXPECT_EQ(1, data.sample_count);
+}

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -41,11 +41,11 @@ constexpr const char kTestNodeName[] = "test_measure_linux_process_cpu";
 constexpr const char kTestTopic[] = "test_process_cpu_measure_topic";
 }
 
-class TestLinuxProcessCpuMeasurementNode : public system_metrics_collector::
+class MockLinuxProcessCpuMeasurementNode : public system_metrics_collector::
   LinuxProcessCpuMeasurementNode
 {
 public:
-  TestLinuxProcessCpuMeasurementNode(
+  MockLinuxProcessCpuMeasurementNode(
     const std::string & name,
     const std::chrono::milliseconds measurement_period,
     const std::string & publishing_topic,
@@ -226,7 +226,7 @@ public:
 
     rclcpp::init(0, nullptr);
 
-    test_node_ = std::make_shared<TestLinuxProcessCpuMeasurementNode>(kTestNodeName,
+    test_node_ = std::make_shared<MockLinuxProcessCpuMeasurementNode>(kTestNodeName,
         test_constants::kMeasurePeriod, kTestTopic, test_constants::kPublishPeriod);
 
     ASSERT_FALSE(test_node_->IsStarted());
@@ -248,7 +248,7 @@ public:
   }
 
 protected:
-  std::shared_ptr<TestLinuxProcessCpuMeasurementNode> test_node_;
+  std::shared_ptr<MockLinuxProcessCpuMeasurementNode> test_node_;
 };
 
 TEST_F(LinuxProcessCpuMeasurementTestFixture, TestGetMetricName) {


### PR DESCRIPTION
This implements the node that does per-process CPU usage collection.

Example debug output:
```
$ ./install/system_metrics_collector/lib/system_metrics_collector/main | grep linuxProcessCpuCollector
[DEBUG] [1578005328.012000628] [linuxProcessCpuCollector]: PerformPeriodicMeasurement: nan
[DEBUG] [1578005328.012084643] [linuxProcessCpuCollector]: name=linuxProcessCpuCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=nan, min=nan, max=nan, std_dev=nan, count=0
[DEBUG] [1578005329.011345403] [linuxProcessCpuCollector]: PerformPeriodicMeasurement: 3.670513
[DEBUG] [1578005329.011465002] [linuxProcessCpuCollector]: name=linuxProcessCpuCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=3.670513, min=3.670513, max=3.670513, std_dev=0.000000, count=1
[DEBUG] [1578005330.011254244] [linuxProcessCpuCollector]: PerformPeriodicMeasurement: 3.843482
[DEBUG] [1578005330.011410743] [linuxProcessCpuCollector]: name=linuxProcessCpuCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=3.756997, min=3.670513, max=3.843482, std_dev=0.086485, count=2
[DEBUG] [1578005331.011297740] [linuxProcessCpuCollector]: PerformPeriodicMeasurement: 4.094694
[DEBUG] [1578005331.011433186] [linuxProcessCpuCollector]: name=linuxProcessCpuCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=3.869563, min=3.670513, max=4.094694, std_dev=0.174150, count=3
[DEBUG] [1578005332.025331858] [linuxProcessCpuCollector]: PerformPeriodicMeasurement: 4.664516
[DEBUG] [1578005332.025468622] [linuxProcessCpuCollector]: name=linuxProcessCpuCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=4.068301, min=3.670513, max=4.664516, std_dev=0.375815, count=4
[DEBUG] [1578005333.028630184] [linuxProcessCpuCollector]: PerformPeriodicMeasurement: 3.307438
[DEBUG] [1578005333.028917962] [linuxProcessCpuCollector]: name=linuxProcessCpuCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=3.916129, min=3.307438, max=4.664516, std_dev=0.453449, count=5
[DEBUG] [1578005334.011455014] [linuxProcessCpuCollector]: PerformPeriodicMeasurement: 3.533342
[DEBUG] [1578005334.011652595] [linuxProcessCpuCollector]: name=linuxProcessCpuCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=3.852331, min=3.307438, max=4.664516, std_dev=0.437832, count=6
[DEBUG] [1578005335.012703392] [linuxProcessCpuCollector]: PerformPeriodicMeasurement: 5.471830
[DEBUG] [1578005335.012868267] [linuxProcessCpuCollector]: name=linuxProcessCpuCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=4.083688, min=3.307438, max=5.471830, std_dev=0.696755, count=7
```

Example topic output:
```
$ ros2 topic echo /not_publishing_yet
measurement_source_name: linuxProcessCpuCollector
metrics_source: 23296_cpu_percent_used
window_start:
  sec: 1578005387
  nanosec: 13896897
window_stop:
  sec: 1578005447
  nanosec: 16203847
statistics:
- data_type: 1
  data: 3.9269039630889893
- data_type: 3
  data: 10.672758102416992
- data_type: 2
  data: 2.0373220443725586
- data_type: 5
  data: 60.0
- data_type: 4
  data: 1.0283935070037842
---
.
.
.
---
measurement_source_name: linuxProcessCpuCollector
metrics_source: 23296_cpu_percent_used
window_start:
  sec: 1578005447
  nanosec: 16265587
window_stop:
  sec: 1578005507
  nanosec: 18301838
statistics:
- data_type: 1
  data: 3.6470861434936523
- data_type: 3
  data: 8.337632179260254
- data_type: 2
  data: 1.4981666803359985
- data_type: 5
  data: 60.0
- data_type: 4
  data: 1.2943096160888672
---
```
