### PR TITLE
Add launch file to launch system CPU and Memory collector nodes

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -114,6 +114,12 @@ if(BUILD_TESTING)
     lib/${PROJECT_NAME})
 endif()
 
+# Install launch files.
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
+
 install(TARGETS
   main
   DESTINATION

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -54,6 +54,14 @@ add_executable(main src/system_metrics_collector/main.cpp)
 target_link_libraries(main system_metrics_collector)
 ament_target_dependencies(main)
 
+add_executable(linux_cpu_collector src/system_metrics_collector/linux_cpu_collector.cpp)
+target_link_libraries(linux_cpu_collector system_metrics_collector)
+ament_target_dependencies(linux_cpu_collector)
+
+add_executable(linux_memory_collector src/system_metrics_collector/linux_memory_collector.cpp)
+target_link_libraries(linux_memory_collector system_metrics_collector)
+ament_target_dependencies(linux_memory_collector)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
@@ -114,14 +122,27 @@ if(BUILD_TESTING)
     lib/${PROJECT_NAME})
 endif()
 
-# Install launch files.
+# Install launch files
 install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}/
 )
 
+# Install entry points
 install(TARGETS
   main
+  DESTINATION
+  lib/${PROJECT_NAME}
+)
+
+install(TARGETS
+  linux_cpu_collector
+  DESTINATION
+  lib/${PROJECT_NAME}
+)
+
+install(TARGETS
+  linux_memory_collector
   DESTINATION
   lib/${PROJECT_NAME}
 )

--- a/system_metrics_collector/launch/system_cpu_and_memory.launch.py
+++ b/system_metrics_collector/launch/system_cpu_and_memory.launch.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch system CPU and system memory metrics collector nodes."""
+
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    """Run system CPU and memory collector nodes using launch."""
+    ld = LaunchDescription([
+        Node(
+            package='system_metrics_collector',
+            node_executable='main',
+            output='screen'),
+    ])
+    return ld

--- a/system_metrics_collector/launch/system_cpu_and_memory.launch.py
+++ b/system_metrics_collector/launch/system_cpu_and_memory.launch.py
@@ -24,7 +24,12 @@ def generate_launch_description():
     ld = LaunchDescription([
         Node(
             package='system_metrics_collector',
-            node_executable='main',
+            node_executable='linux_cpu_collector',
             output='screen'),
+        Node(
+            package='system_metrics_collector',
+            node_executable='linux_memory_collector',
+            output='screen'
+        ),
     ])
     return ld

--- a/system_metrics_collector/src/system_metrics_collector/constants.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/constants.hpp
@@ -1,0 +1,27 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_
+#define SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_
+
+#include <chrono>
+
+namespace CollectorNodeConstants
+{
+constexpr const char kStatisticsTopicName[] = "system_metrics";
+constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
+constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
+}
+
+#endif  // SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/constants.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/constants.hpp
@@ -17,11 +17,18 @@
 
 #include <chrono>
 
-namespace CollectorNodeConstants
+namespace system_metrics_collector
 {
+
+namespace collector_node_constants
+{
+
 constexpr const char kStatisticsTopicName[] = "system_metrics";
 constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
 constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
-}
+
+}  // namespace collector_node_constants
+
+}  // namespace system_metrics_collector
 
 #endif  // SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
@@ -31,9 +31,9 @@ int main(int argc, char ** argv)
 
   const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
     "linuxCpuCollector",
-    CollectorNodeConstants::kDefaultCollectPeriod,
-    CollectorNodeConstants::kStatisticsTopicName,
-    CollectorNodeConstants::kDefaultPublishPeriod);
+    system_metrics_collector::collector_node_constants::kDefaultCollectPeriod,
+    system_metrics_collector::collector_node_constants::kStatisticsTopicName,
+    system_metrics_collector::collector_node_constants::kDefaultPublishPeriod);
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
@@ -18,38 +18,25 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/logging_macros.h"
 
+#include "../../src/system_metrics_collector/constants.hpp"
 #include "../../src/system_metrics_collector/linux_cpu_measurement_node.hpp"
 
-namespace
-{
-constexpr const char kStatisticsTopicName[] = "system_metrics";
-constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
-constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
-}
+/**
+* An entry point that starts the linux system CPU metric collector node.
+*/
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  using namespace std::chrono_literals;
   const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
     "linuxCpuCollector",
-    kDefaultCollectPeriod,
-    kStatisticsTopicName,
-    kDefaultPublishPeriod);
+    CollectorNodeConstants::kDefaultCollectPeriod,
+    CollectorNodeConstants::kStatisticsTopicName,
+    CollectorNodeConstants::kDefaultPublishPeriod);
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->Start();
-
-  {
-    const auto r =
-      rcutils_logging_set_logger_level(cpu_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-    if (r != 0) {
-      RCUTILS_LOG_ERROR_NAMED("linux_cpu_main",
-        "Unable to set debug logging for the cpu node: %s\n",
-        rcutils_get_error_string().str);
-    }
-  }
 
   ex.add_node(cpu_node);
   ex.spin();

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
@@ -1,0 +1,60 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/logging_macros.h"
+
+#include "../../src/system_metrics_collector/linux_cpu_measurement_node.hpp"
+
+namespace
+{
+constexpr const char kStatisticsTopicName[] = "system_metrics";
+constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
+constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  using namespace std::chrono_literals;
+  const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
+    "linuxCpuCollector",
+    kDefaultCollectPeriod,
+    kStatisticsTopicName,
+    kDefaultPublishPeriod);
+
+  rclcpp::executors::MultiThreadedExecutor ex;
+  cpu_node->Start();
+
+  {
+    const auto r =
+      rcutils_logging_set_logger_level(cpu_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+    if (r != 0) {
+      RCUTILS_LOG_ERROR_NAMED("linux_cpu_main",
+        "Unable to set debug logging for the cpu node: %s\n",
+        rcutils_get_error_string().str);
+    }
+  }
+
+  ex.add_node(cpu_node);
+  ex.spin();
+
+  rclcpp::shutdown();
+  cpu_node->Stop();
+  return 0;
+}

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
@@ -30,9 +30,9 @@ int main(int argc, char ** argv)
 
   const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector",
-    CollectorNodeConstants::kDefaultCollectPeriod,
-    CollectorNodeConstants::kStatisticsTopicName,
-    CollectorNodeConstants::kDefaultPublishPeriod);
+    system_metrics_collector::collector_node_constants::kDefaultCollectPeriod,
+    system_metrics_collector::collector_node_constants::kStatisticsTopicName,
+    system_metrics_collector::collector_node_constants::kDefaultPublishPeriod);
 
   rclcpp::executors::MultiThreadedExecutor ex;
   mem_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
@@ -1,0 +1,59 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/logging_macros.h"
+
+#include "../../src/system_metrics_collector/linux_memory_measurement_node.hpp"
+
+namespace
+{
+constexpr const char kStatisticsTopicName[] = "system_metrics";
+constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
+constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  using namespace std::chrono_literals;
+  const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
+    "linuxMemoryCollector",
+    kDefaultCollectPeriod,
+    kStatisticsTopicName,
+    kDefaultPublishPeriod);
+
+  rclcpp::executors::MultiThreadedExecutor ex;
+  mem_node->Start();
+
+  {
+    const auto r =
+      rcutils_logging_set_logger_level(mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+    if (r != 0) {
+      RCUTILS_LOG_ERROR_NAMED("linux_mem_main",
+        "Unable to set debug logging for the memory node: %s\n",
+        rcutils_get_error_string().str);
+    }
+  }
+
+  ex.add_node(mem_node);
+  ex.spin();
+
+  rclcpp::shutdown();
+  mem_node->Stop();
+  return 0;
+}

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
@@ -17,38 +17,25 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/logging_macros.h"
 
+#include "../../src/system_metrics_collector/constants.hpp"
 #include "../../src/system_metrics_collector/linux_memory_measurement_node.hpp"
 
-namespace
-{
-constexpr const char kStatisticsTopicName[] = "system_metrics";
-constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
-constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
-}
+/**
+* An entry point that starts the linux system memory metric collector node.
+*/
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  using namespace std::chrono_literals;
   const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector",
-    kDefaultCollectPeriod,
-    kStatisticsTopicName,
-    kDefaultPublishPeriod);
+    CollectorNodeConstants::kDefaultCollectPeriod,
+    CollectorNodeConstants::kStatisticsTopicName,
+    CollectorNodeConstants::kDefaultPublishPeriod);
 
   rclcpp::executors::MultiThreadedExecutor ex;
   mem_node->Start();
-
-  {
-    const auto r =
-      rcutils_logging_set_logger_level(mem_node->get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-    if (r != 0) {
-      RCUTILS_LOG_ERROR_NAMED("linux_mem_main",
-        "Unable to set debug logging for the memory node: %s\n",
-        rcutils_get_error_string().str);
-    }
-  }
 
   ex.add_node(mem_node);
   ex.spin();


### PR DESCRIPTION
Related to https://github.com/ros-security/aws-roadmap/issues/149.

Testing:

```bash
➜  ros2_ws git:(master) ✗ ros2 launch system_metrics_collector system_cpu_and_memory.launch.py

[INFO] [launch]: All log files can be found below /home/ANT.AMAZON.COM/prajaktg/.ros/log/2020-01-08-13-04-27-713008-u50b388d95c3157.ant.amazon.com-8591
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [linux_cpu_collector-1]: process started with pid [8601]
[INFO] [linux_memory_collector-2]: process started with pid [8602]
[linux_cpu_collector-1] [ERROR] [ComputeCpuActivePercentage]: a measurement was empty, unable to compute cpu percentage
[linux_memory_collector-2] [DEBUG] [linuxMemoryCollector]: PerformPeriodicMeasurement: 11.799179
[linux_memory_collector-2] [DEBUG] [linuxMemoryCollector]: name=linuxMemoryCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=11.799179, min=11.799179, max=11.799179, std_dev=0.000000, count=1
...
[linux_cpu_collector-1] [DEBUG] [linuxCpuCollector]: PerformPeriodicMeasurement: nan
[linux_cpu_collector-1] [DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=nan, min=nan, max=nan, std_dev=nan, count=0
[linux_cpu_collector-1] [DEBUG] [linuxCpuCollector]: PerformPeriodicMeasurement: 3.015075
[linux_cpu_collector-1] [DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=3.015075, min=3.015075, max=3.015075, std_dev=0.000000, count=1
...
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[main-1] [DEBUG] [linuxMemoryCollector]: name=linuxMemoryCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=11.976991, min=11.974837, max=11.978395, std_dev=0.001555, count=5
[main-1] [DEBUG] [linuxProcessMemoryCollector]: PerformPeriodicMeasurement: 0.002625
[main-1] [DEBUG] [linuxProcessMemoryCollector]: name=linuxProcessMemoryCollector, measurement_period=1000ms, publishing_topic=not_publishing_yet, publish_period=60000ms, started=true, avg=0.002585, min=0.002428, max=0.002625, std_dev=0.000079, count=5
[linux_memory_collector-2] [INFO] [rclcpp]: signal_handler(signal_value=2)
[INFO] [linux_cpu_collector-1]: process has finished cleanly [pid 8601]
[INFO] [linux_memory_collector-2]: process has finished cleanly [pid 8602]
[linux_cpu_collector-1] [DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=3.632821, min=2.538071, max=5.941846, std_dev=1.070607, count=14
[linux_cpu_collector-1] [DEBUG] [linuxCpuCollector]: PerformPeriodicMeasurement: 3.136763
[linux_cpu_collector-1] [DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=3.599750, min=2.538071, max=5.941846, std_dev=1.041680, count=15
[linux_cpu_collector-1] [INFO] [rclcpp]: signal_handler(signal_value=2)


➜  ros2 run system_metrics_collector linux_cpu_collector

[ERROR] [ComputeCpuActivePercentage]: a measurement was empty, unable to compute cpu percentage
[DEBUG] [linuxCpuCollector]: PerformPeriodicMeasurement: nan
[DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=nan, min=nan, max=nan, std_dev=nan, count=0
[DEBUG] [linuxCpuCollector]: PerformPeriodicMeasurement: 2.339901
[DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=2.339901, min=2.339901, max=2.339901, std_dev=0.000000, count=1
[DEBUG] [linuxCpuCollector]: PerformPeriodicMeasurement: 3.166870
[DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=2.753386, min=2.339901, max=3.166870, std_dev=0.413484, count=2
[DEBUG] [linuxCpuCollector]: PerformPeriodicMeasurement: 2.910053
[DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=2.805608, min=2.339901, max=3.166870, std_dev=0.345592, count=3
[DEBUG] [linuxCpuCollector]: PerformPeriodicMeasurement: 4.630788
[DEBUG] [linuxCpuCollector]: name=linuxCpuCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=3.261903, min=2.339901, max=4.630788, std_dev=0.845098, count=4
^C[INFO] [rclcpp]: signal_handler(signal_value=2)

➜  ros2 run system_metrics_collector linux_memory_collector

[DEBUG] [linuxMemoryCollector]: PerformPeriodicMeasurement: 11.750890
[DEBUG] [linuxMemoryCollector]: name=linuxMemoryCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=11.750890, min=11.750890, max=11.750890, std_dev=0.000000, count=1
[DEBUG] [linuxMemoryCollector]: PerformPeriodicMeasurement: 11.750890
[DEBUG] [linuxMemoryCollector]: name=linuxMemoryCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=11.750890, min=11.750890, max=11.750890, std_dev=0.000000, count=2
[DEBUG] [linuxMemoryCollector]: PerformPeriodicMeasurement: 11.751062
[DEBUG] [linuxMemoryCollector]: name=linuxMemoryCollector, measurement_period=1000ms, publishing_topic=system_metrics, publish_period=60000ms, started=true, avg=11.750948, min=11.750890, max=11.751062, std_dev=0.000081, count=3
^C[INFO] [rclcpp]: signal_handler(signal_value=2)
```


Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>