### PR TITLE
Added publish period attribute as a parameter

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -48,11 +48,17 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
     throw std::invalid_argument{"publishing_topic cannot be empty"};
   }
 
-  if (publish_period <= std::chrono::milliseconds{0}) {
+  int publish_period_param = 0;
+  declare_parameter("publish_period");
+  if (get_parameter("publish_period", publish_period_param)) {
+    publish_period_ = std::chrono::milliseconds(publish_period_param);
+  }
+
+  if (publish_period_ <= std::chrono::milliseconds{0}) {
     throw std::invalid_argument{"publish_period cannot be negative"};
   }
 
-  if (publish_period <= measurement_period) {
+  if (publish_period_ <= measurement_period) {
     throw std::invalid_argument{
             "publish_period cannot be less than or equal to the measurement_period"};
   }

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -49,7 +49,9 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
   }
 
   int publish_period_param = 0;
-  declare_parameter("publish_period");
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.read_only = true;
+  declare_parameter("publish_period", publish_period_.count(), descriptor);
   if (get_parameter("publish_period", publish_period_param)) {
     publish_period_ = std::chrono::milliseconds(publish_period_param);
   }

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -116,7 +116,7 @@ private:
   /**
    * The period used to publish measurement data
    */
-  const std::chrono::milliseconds publish_period_;
+  std::chrono::milliseconds publish_period_;
 
   rclcpp::TimerBase::SharedPtr measurement_timer_;
   rclcpp::TimerBase::SharedPtr publish_timer_;


### PR DESCRIPTION
By default the publish rate is [hardcoded to 1 minute](https://github.com/ros-tooling/system_metrics_collector/blob/master/system_metrics_collector/src/system_metrics_collector/constants.hpp#L28)

This PR allows to change this value using ROS 2 parameters