### PR TITLE
Refactor PeriodicMeasurementNode to inherit from LifecycleNode

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(metrics_statistics_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 
@@ -48,7 +49,7 @@ add_library(system_metrics_collector SHARED
   src/system_metrics_collector/proc_pid_cpu_data.cpp
   src/system_metrics_collector/utilities.cpp
 )
-ament_target_dependencies(system_metrics_collector metrics_statistics_msgs rclcpp rcpputils rcutils)
+ament_target_dependencies(system_metrics_collector metrics_statistics_msgs rclcpp rclcpp_lifecycle rcpputils rcutils)
 ament_export_libraries(system_metrics_collector)
 
 add_executable(main src/system_metrics_collector/main.cpp)

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -49,7 +49,12 @@ add_library(system_metrics_collector SHARED
   src/system_metrics_collector/proc_pid_cpu_data.cpp
   src/system_metrics_collector/utilities.cpp
 )
-ament_target_dependencies(system_metrics_collector metrics_statistics_msgs rclcpp rclcpp_lifecycle rcpputils rcutils)
+ament_target_dependencies(system_metrics_collector
+        metrics_statistics_msgs
+        rclcpp
+        rclcpp_lifecycle
+        rcpputils
+        rcutils)
 ament_export_libraries(system_metrics_collector)
 
 add_executable(main src/system_metrics_collector/main.cpp)

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -67,6 +67,7 @@ ament_target_dependencies(linux_memory_collector)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(lifecycle_msgs REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 
@@ -88,17 +89,17 @@ if(BUILD_TESTING)
   ament_add_gtest(test_linux_memory_measurement_node
           test/system_metrics_collector/test_linux_memory_measurement.cpp)
   target_link_libraries(test_linux_memory_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_linux_memory_measurement_node metrics_statistics_msgs rclcpp)
+  ament_target_dependencies(test_linux_memory_measurement_node lifecycle_msgs metrics_statistics_msgs rclcpp)
 
   ament_add_gtest(test_linux_process_cpu_measurement_node
           test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp)
   target_link_libraries(test_linux_process_cpu_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_linux_process_cpu_measurement_node metrics_statistics_msgs rclcpp)
+  ament_target_dependencies(test_linux_process_cpu_measurement_node lifecycle_msgs metrics_statistics_msgs rclcpp)
 
   ament_add_gtest(test_linux_process_memory_measurement_node
           test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp)
   target_link_libraries(test_linux_process_memory_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_linux_process_memory_measurement_node metrics_statistics_msgs rclcpp)
+  ament_target_dependencies(test_linux_process_memory_measurement_node lifecycle_msgs metrics_statistics_msgs rclcpp)
 
   ament_add_gtest(test_moving_average_statistics
           test/moving_average_statistics/test_moving_average_statistics.cpp)
@@ -108,7 +109,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_periodic_measurement_node
     test/system_metrics_collector/test_periodic_measurement_node.cpp)
   target_link_libraries(test_periodic_measurement_node system_metrics_collector)
-  ament_target_dependencies(test_periodic_measurement_node metrics_statistics_msgs rclcpp)
+  ament_target_dependencies(test_periodic_measurement_node lifecycle_msgs metrics_statistics_msgs rclcpp)
 
   ament_add_gtest(test_utilities
           test/system_metrics_collector/test_utilities.cpp)

--- a/system_metrics_collector/package.xml
+++ b/system_metrics_collector/package.xml
@@ -24,6 +24,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>lifecycle_msgs</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rcpputils</test_depend>
   <test_depend>rcutils</test_depend>

--- a/system_metrics_collector/package.xml
+++ b/system_metrics_collector/package.xml
@@ -10,11 +10,13 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rcpputils</build_depend>
   <build_depend>metrics_statistics_msgs</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>rcpputils</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>metrics_statistics_msgs</exec_depend>

--- a/system_metrics_collector/src/system_metrics_collector/collector.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.hpp
@@ -36,24 +36,6 @@ public:
   virtual ~Collector() = default;
 
   /**
-   * Start collecting data. Meant to be called after construction. Note: this locks the recursive mutex class
-   * member 'mutex'.
-   *
-   * @return true if started, false if an error occurred
-   */
-  bool Start();
-
-  /**
-   * Stop collecting data. Meant to be a teardown method (before destruction, but should place the
-   * class in a restartable state, i.e., start can be called to be able to resume collection.
-   *
-   * This calls ClearCurrentMeasurements.
-   *
-   * @return true if stopped, false if an error occurred
-   */
-  bool Stop();
-
-  /**
    * Add an observed measurement. This aggregates the measurement and calculates statistics
    * via the moving_average class.
    *
@@ -88,6 +70,25 @@ public:
   virtual std::string GetStatusString() const;
 
   // todo @dabonnie uptime (once start has been called)
+
+protected:
+  /**
+   * Start collecting data. Meant to be called after construction. Note: this locks the recursive mutex class
+   * member 'mutex'.
+   *
+   * @return true if started, false if an error occurred
+   */
+  virtual bool Start();
+
+  /**
+   * Stop collecting data. Meant to be a teardown method (before destruction, but should place the
+   * class in a restartable state, i.e., start can be called to be able to resume collection.
+   *
+   * This calls ClearCurrentMeasurements.
+   *
+   * @return true if stopped, false if an error occurred
+   */
+  virtual bool Stop();
 
 private:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
@@ -33,12 +33,14 @@ int main(int argc, char ** argv)
     std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>("linuxCpuCollector");
 
   rclcpp::executors::MultiThreadedExecutor ex;
-  cpu_node->Start();
+  cpu_node->configure();
+  cpu_node->activate();
 
   ex.add_node(cpu_node->get_node_base_interface());
   ex.spin();
 
   rclcpp::shutdown();
-  cpu_node->Stop();
+  cpu_node->deactivate();
+
   return 0;
 }

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
@@ -35,7 +35,7 @@ int main(int argc, char ** argv)
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->Start();
 
-  ex.add_node(cpu_node);
+  ex.add_node(cpu_node->get_node_base_interface());
   ex.spin();
 
   rclcpp::shutdown();

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
@@ -33,12 +33,14 @@ int main(int argc, char ** argv)
     "linuxMemoryCollector");
 
   rclcpp::executors::MultiThreadedExecutor ex;
-  mem_node->Start();
+  mem_node->configure();
+  mem_node->activate();
 
   ex.add_node(mem_node->get_node_base_interface());
   ex.spin();
 
   rclcpp::shutdown();
-  mem_node->Stop();
+  mem_node->shutdown();
+
   return 0;
 }

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
@@ -35,7 +35,7 @@ int main(int argc, char ** argv)
   rclcpp::executors::MultiThreadedExecutor ex;
   mem_node->Start();
 
-  ex.add_node(mem_node);
+  ex.add_node(mem_node->get_node_base_interface());
   ex.spin();
 
   rclcpp::shutdown();

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -76,10 +76,10 @@ int main(int argc, char ** argv)
   set_node_to_debug(process_cpu_node.get(), "process cpu");
   set_node_to_debug(process_mem_node.get(), "process memory");
 
-  ex.add_node(cpu_node);
-  ex.add_node(mem_node);
-  ex.add_node(process_cpu_node);
-  ex.add_node(process_mem_node);
+  ex.add_node(cpu_node->get_node_base_interface());
+  ex.add_node(mem_node->get_node_base_interface());
+  ex.add_node(process_cpu_node->get_node_base_interface());
+  ex.add_node(process_mem_node->get_node_base_interface());
   ex.spin();
 
   rclcpp::shutdown();

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -79,9 +79,9 @@ int main(int argc, char ** argv)
   set_node_to_debug(process_mem_node.get(), "process memory");
 
   ex.add_node(cpu_node->get_node_base_interface());
-//  ex.add_node(mem_node->get_node_base_interface());
-//  ex.add_node(process_cpu_node->get_node_base_interface());
-//  ex.add_node(process_mem_node->get_node_base_interface());
+  ex.add_node(mem_node->get_node_base_interface());
+  ex.add_node(process_cpu_node->get_node_base_interface());
+  ex.add_node(process_mem_node->get_node_base_interface());
   ex.spin();
 
   rclcpp::shutdown();

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -69,9 +69,14 @@ int main(int argc, char ** argv)
   cpu_node->configure();
   cpu_node->activate();
 
-  mem_node->Start();
-  process_cpu_node->Start();
-  process_mem_node->Start();
+  mem_node->configure();
+  mem_node->activate();
+
+  process_cpu_node->configure();
+  process_cpu_node->activate();
+
+  process_mem_node->configure();
+  process_mem_node->activate();
 
   set_node_to_debug(cpu_node.get(), "cpu");
   set_node_to_debug(mem_node.get(), "memory");
@@ -86,10 +91,10 @@ int main(int argc, char ** argv)
 
   rclcpp::shutdown();
 
-  cpu_node->Stop();
-  mem_node->Stop();
-  process_cpu_node->Stop();
-  process_mem_node->Stop();
+  cpu_node->shutdown();
+  mem_node->shutdown();
+  process_cpu_node->shutdown();
+  process_mem_node->shutdown();
 
   return 0;
 }

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -66,7 +66,9 @@ int main(int argc, char ** argv)
     "linuxProcessMemoryCollector");
 
   rclcpp::executors::MultiThreadedExecutor ex;
-  cpu_node->Start();
+  cpu_node->configure();
+  cpu_node->activate();
+
   mem_node->Start();
   process_cpu_node->Start();
   process_mem_node->Start();
@@ -77,9 +79,9 @@ int main(int argc, char ** argv)
   set_node_to_debug(process_mem_node.get(), "process memory");
 
   ex.add_node(cpu_node->get_node_base_interface());
-  ex.add_node(mem_node->get_node_base_interface());
-  ex.add_node(process_cpu_node->get_node_base_interface());
-  ex.add_node(process_mem_node->get_node_base_interface());
+//  ex.add_node(mem_node->get_node_base_interface());
+//  ex.add_node(process_cpu_node->get_node_base_interface());
+//  ex.add_node(process_mem_node->get_node_base_interface());
   ex.spin();
 
   rclcpp::shutdown();

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -119,7 +119,6 @@ PeriodicMeasurementNode::on_shutdown(const rclcpp_lifecycle::State & state)
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-
 bool PeriodicMeasurementNode::SetupStop()
 {
   assert(measurement_timer_ != nullptr);

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -31,7 +31,7 @@ namespace system_metrics_collector
 PeriodicMeasurementNode::PeriodicMeasurementNode(
   const std::string & name,
   const rclcpp::NodeOptions & options)
-: Node{name, options}
+: rclcpp_lifecycle::LifecycleNode{name, options}
 {
   rcl_interfaces::msg::IntegerRange positive_range;
   positive_range.from_value = 1;

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -98,16 +98,18 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 PeriodicMeasurementNode::on_activate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_DEBUG(this->get_logger(), "on_activate");
-  Start();
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  auto const ret = Start();
+  return ret ? rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS :
+         rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 PeriodicMeasurementNode::on_deactivate(const rclcpp_lifecycle::State & state)
 {
   RCLCPP_DEBUG(this->get_logger(), "on_deactivate");
-  Stop();
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  auto const ret = Stop();
+  return ret ? rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS :
+         rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
@@ -116,6 +118,17 @@ PeriodicMeasurementNode::on_shutdown(const rclcpp_lifecycle::State & state)
   RCLCPP_DEBUG(this->get_logger(), "on_shutdown");
   Stop();
   publisher_.reset();
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+PeriodicMeasurementNode::on_error(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_DEBUG(this->get_logger(), "on_shutdown");
+  Stop();
+  if (publisher_) {
+    publisher_.reset();
+  }
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -112,7 +112,7 @@ protected:
    * LifecyclePublisher publisher that is activated on SetupStart and deactivated on SetupStop().
    */
   rclcpp_lifecycle::LifecyclePublisher<metrics_statistics_msgs::msg::MetricsMessage>::SharedPtr
-    publisher_; //todo unique ptr
+    publisher_;
 
 private:
   /**
@@ -147,12 +147,12 @@ private:
   /**
    * ROS2 timer used to trigger collection measurements.
    */
-  rclcpp::TimerBase::SharedPtr measurement_timer_; //todo unique ptr
+  rclcpp::TimerBase::SharedPtr measurement_timer_;
 
   /**
    * ROS2 timer used to publish measurement messages.
    */
-  rclcpp::TimerBase::SharedPtr publish_timer_; //todo unique ptr
+  rclcpp::TimerBase::SharedPtr publish_timer_;
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -57,6 +57,15 @@ public:
    */
   std::string GetStatusString() const override;
 
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State & state);
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State & state);
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(
+    const rclcpp_lifecycle::State & state);
+
 protected:
   /**
    * Create ROS2 timers and a publisher for periodically triggering measurements
@@ -78,7 +87,8 @@ protected:
    */
   rclcpp::Time window_start_;
 
-  rclcpp::Publisher<metrics_statistics_msgs::msg::MetricsMessage>::SharedPtr publisher_;
+  rclcpp_lifecycle::LifecyclePublisher<metrics_statistics_msgs::msg::MetricsMessage>::SharedPtr
+    publisher_;
 
 private:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -61,7 +61,7 @@ public:
    * Implementation of the on_activate transition for this LifecycleNode. This calls
    * the Start() method.
    *
-   * @param state input state
+   * @param state input state unused
    * @return CallbackReturn success
    */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(
@@ -71,7 +71,7 @@ public:
    * Implementation of the on_deactivate transition for this LifecycleNode. This calls
    * the Stop() method.
    *
-   * @param input state
+   * @param input state unused
    * @return CallbackReturn success
    */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
@@ -81,7 +81,7 @@ public:
    * Implementation of the on_shutdown transition for this LifecycleNode. This calls
    * the Stop() method and resets the publish_timer_ member.
    *
-   * @param input state
+   * @param input state unused
    * @return CallbackReturn success
    */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -57,12 +57,33 @@ public:
    */
   std::string GetStatusString() const override;
 
+  /**
+   * Implementation of the on_activate transition for this LifecycleNode. This calls
+   * the Start() method.
+   *
+   * @param state input state
+   * @return CallbackReturn success
+   */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(
     const rclcpp_lifecycle::State & state);
 
+  /**
+   * Implementation of the on_deactivate transition for this LifecycleNode. This calls
+   * the Stop() method.
+   *
+   * @param input state
+   * @return CallbackReturn success
+   */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
     const rclcpp_lifecycle::State & state);
 
+  /**
+   * Implementation of the on_shutdown transition for this LifecycleNode. This calls
+   * the Stop() method and resets the publish_timer_ member.
+   *
+   * @param input state
+   * @return CallbackReturn success
+   */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(
     const rclcpp_lifecycle::State & state);
 
@@ -87,13 +108,16 @@ protected:
    */
   rclcpp::Time window_start_;
 
+  /**
+   * LifecyclePublisher publisher that is activated on SetupStart and deactivated on SetupStop().
+   */
   rclcpp_lifecycle::LifecyclePublisher<metrics_statistics_msgs::msg::MetricsMessage>::SharedPtr
-    publisher_;
+    publisher_; //todo unique ptr
 
 private:
   /**
-   * Override this method to perform a single measurement. This is called via PerformPeriodicMeasurement
-   * with the period defined in the constructor.
+   * Override this method to perform a single measurement. This is called via
+   * PerformPeriodicMeasurement with the period defined in the constructor.
    *
    * @return the measurement made to be aggregated for statistics
    */
@@ -120,8 +144,15 @@ private:
    */
   std::chrono::milliseconds publish_period_;
 
-  rclcpp::TimerBase::SharedPtr measurement_timer_;
-  rclcpp::TimerBase::SharedPtr publish_timer_;
+  /**
+   * ROS2 timer used to trigger collection measurements.
+   */
+  rclcpp::TimerBase::SharedPtr measurement_timer_; //todo unique ptr
+
+  /**
+   * ROS2 timer used to publish measurement messages.
+   */
+  rclcpp::TimerBase::SharedPtr publish_timer_; //todo unique ptr
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -21,10 +21,10 @@
 
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "collector.hpp"
 #include "metrics_message_publisher.hpp"
-
 
 namespace system_metrics_collector
 {
@@ -33,7 +33,7 @@ namespace system_metrics_collector
  * Class which makes periodic measurements, using a ROS2 timer.
  */
 class PeriodicMeasurementNode : public system_metrics_collector::Collector,
-  public system_metrics_collector::MetricsMessagePublisher, public rclcpp::Node
+  public system_metrics_collector::MetricsMessagePublisher, public rclcpp_lifecycle::LifecycleNode
 {
 public:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -62,7 +62,7 @@ public:
    * the Start() method.
    *
    * @param state input state unused
-   * @return CallbackReturn success
+   * @return CallbackReturn success if start returns true, error otherwise
    */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(
     const rclcpp_lifecycle::State & state);
@@ -72,7 +72,7 @@ public:
    * the Stop() method.
    *
    * @param input state unused
-   * @return CallbackReturn success
+   * @return CallbackReturn success if start returns true, error otherwise
    */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
     const rclcpp_lifecycle::State & state);
@@ -86,6 +86,16 @@ public:
    */
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(
     const rclcpp_lifecycle::State & state);
+
+  /**
+   * Implementation of the on_error transition for this LifecycleNode. This calls
+   * the Stop() method and resets the publish_timer_ member if it is non-null.
+   *
+   * @param input state unused
+   * @return CallbackReturn success
+   */
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_error(
+    const rclcpp_lifecycle::State & previous_state);
 
 protected:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -37,7 +37,7 @@ class PeriodicMeasurementNode : public system_metrics_collector::Collector,
 {
 public:
   /**
-   * Construct a PeriodicMeasurementNode.
+   * Constructs a PeriodicMeasurementNode.
    * The following parameters may be set via the rclcpp::NodeOptions:
    * `measurement_period`: the period of this node, used to read measurements
    * `publish_period`: the period at which metrics are published
@@ -51,15 +51,14 @@ public:
   virtual ~PeriodicMeasurementNode() = default;
 
   /**
-   * Return a pretty printed status representation of this class
+   * Returns a pretty printed status representation of this class
    *
    * @return a string detailing the current status
    */
   std::string GetStatusString() const override;
 
   /**
-   * Implementation of the on_activate transition for this LifecycleNode. This calls
-   * the Start() method.
+   * Starts the node.
    *
    * @param state input state unused
    * @return CallbackReturn success if start returns true, error otherwise
@@ -68,8 +67,7 @@ public:
     const rclcpp_lifecycle::State & state);
 
   /**
-   * Implementation of the on_deactivate transition for this LifecycleNode. This calls
-   * the Stop() method.
+   * Stops the node.
    *
    * @param input state unused
    * @return CallbackReturn success if start returns true, error otherwise
@@ -78,8 +76,7 @@ public:
     const rclcpp_lifecycle::State & state);
 
   /**
-   * Implementation of the on_shutdown transition for this LifecycleNode. This calls
-   * the Stop() method and resets the publish_timer_ member.
+   * Stops the node and performs cleanup.
    *
    * @param input state unused
    * @return CallbackReturn success
@@ -88,8 +85,7 @@ public:
     const rclcpp_lifecycle::State & state);
 
   /**
-   * Implementation of the on_error transition for this LifecycleNode. This calls
-   * the Stop() method and resets the publish_timer_ member if it is non-null.
+   * Stops the node and attempts to perform cleanup.
    *
    * @param input state unused
    * @return CallbackReturn success
@@ -99,7 +95,7 @@ public:
 
 protected:
   /**
-   * Create ROS2 timers and a publisher for periodically triggering measurements
+   * Creates ROS2 timers and a publisher for periodically triggering measurements
    * and publishing MetricsMessages
    *
    * @return if setup was successful
@@ -107,14 +103,14 @@ protected:
   bool SetupStart() override;
 
   /**
-   * Stop the ROS2 timers that were created by SetupStart()
+   * Stops the ROS2 timers that were created by SetupStart()
    *
    * @return if teardown was successful
    */
   bool SetupStop() override;
 
   /**
-   * Track the starting time of the statistics
+   * Tracks the starting time of the statistics
    */
   rclcpp::Time window_start_;
 
@@ -140,7 +136,7 @@ private:
   virtual void PerformPeriodicMeasurement();
 
   /**
-   * Publish the statistics derived from the collected measurements (this is to be called via a
+   * Publishes the statistics derived from the collected measurements (this is to be called via a
    * ROS2 timer per the publish_period)
    */
   void PublishStatisticMessage() override;

--- a/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
@@ -28,6 +28,24 @@ class TestCollector : public system_metrics_collector::Collector
 public:
   TestCollector() = default;
   ~TestCollector() override = default;
+
+  /**
+   * Overrides to make public for testing.
+   * @return
+   */
+  bool Start() override
+  {
+    return Collector::Start();
+  }
+  /**
+   * Overrides to make public for testing.
+   * @return
+   */
+  bool Stop() override
+  {
+    return Collector::Stop();
+  }
+
   bool SetupStart() override
   {
     return true;

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -34,6 +34,9 @@
 
 #include "test_constants.hpp"
 
+#include "rclcpp/rclcpp.hpp"
+
+
 using metrics_statistics_msgs::msg::MetricsMessage;
 using metrics_statistics_msgs::msg::StatisticDataPoint;
 using metrics_statistics_msgs::msg::StatisticDataType;
@@ -47,7 +50,9 @@ constexpr const char kTestNodeName[] = "test_measure_linux_cpu";
 constexpr const char kTestMetricName[] = "system_cpu_percent_used";
 }  // namespace
 
-
+/**
+ * Test class used to fake out linux CPU measurements
+ */
 class TestLinuxCpuMeasurementNode : public system_metrics_collector::LinuxCpuMeasurementNode
 {
 public:
@@ -71,7 +76,9 @@ private:
 
   int measurement_index_{0};
 };
-
+/**
+ * Subscriber for messages sent by the TestLinuxCpuMeasurementNode
+ */
 class TestReceiveCpuMeasurementNode : public rclcpp::Node
 {
 public:
@@ -234,7 +241,10 @@ public:
 
   void TearDown() override
   {
-    test_measure_linux_cpu_->Stop();
+    test_measure_linux_cpu_->shutdown();
+    EXPECT_EQ(4, test_measure_linux_cpu_->get_current_state().id());
+    EXPECT_FALSE(test_measure_linux_cpu_->IsStarted());
+
     test_measure_linux_cpu_.reset();
     rclcpp::shutdown();
   }
@@ -257,23 +267,30 @@ TEST_F(LinuxCpuMeasurementTestFixture, TestPublishMetricsMessage)
 {
   ASSERT_NE(test_measure_linux_cpu_, nullptr);
   ASSERT_FALSE(test_measure_linux_cpu_->IsStarted());
+  ASSERT_EQ(1, test_measure_linux_cpu_->get_current_state().id());
 
   auto test_receive_measurements = std::make_shared<TestReceiveCpuMeasurementNode>(
     "test_receive_measurements");
   std::promise<bool> empty_promise;
   std::shared_future<bool> dummy_future = empty_promise.get_future();
   rclcpp::executors::SingleThreadedExecutor ex;
+
   ex.add_node(test_measure_linux_cpu_->get_node_base_interface());
   ex.add_node(test_receive_measurements->get_node_base_interface());
 
   //
   // spin the node with it started
   //
-  bool start_success = test_measure_linux_cpu_->Start();
-  ASSERT_TRUE(start_success);
+  test_measure_linux_cpu_->configure();
+  ASSERT_EQ(2, test_measure_linux_cpu_->get_current_state().id());
+
+  test_measure_linux_cpu_->activate();
   ASSERT_TRUE(test_measure_linux_cpu_->IsStarted());
+  ASSERT_EQ(3, test_measure_linux_cpu_->get_current_state().id());
+
   ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
-  EXPECT_EQ(3, test_receive_measurements->GetNumReceived());
+
+  ASSERT_EQ(3, test_receive_measurements->GetNumReceived());
   // expectation is:
   // 50 ms: kProcSamples[0] is collected
   // 80 ms: statistics derived from kProcSamples[N/A-0] is published. statistics are cleared
@@ -294,13 +311,14 @@ TEST_F(LinuxCpuMeasurementTestFixture, TestPublishMetricsMessage)
   EXPECT_EQ(1, data.sample_count);
 
   //
-  // spin the node with it stopped
+  // spin the node with it deactivated
   //
-  bool stop_success = test_measure_linux_cpu_->Stop();
-  ASSERT_TRUE(stop_success);
+  test_measure_linux_cpu_->deactivate();
+  ASSERT_EQ(2, test_measure_linux_cpu_->get_current_state().id());
   ASSERT_FALSE(test_measure_linux_cpu_->IsStarted());
+
   ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
-  EXPECT_EQ(3, test_receive_measurements->GetNumReceived());
+  ASSERT_EQ(3, test_receive_measurements->GetNumReceived());
   // expectation is:
   // upon calling stop, samples are cleared, so GetStatisticsResults() would be NaNs
   // no MetricsMessages are published
@@ -314,9 +332,10 @@ TEST_F(LinuxCpuMeasurementTestFixture, TestPublishMetricsMessage)
   //
   // spin the node with it restarted
   //
-  start_success = test_measure_linux_cpu_->Start();
-  ASSERT_TRUE(start_success);
+  test_measure_linux_cpu_->activate();
   ASSERT_TRUE(test_measure_linux_cpu_->IsStarted());
+  ASSERT_EQ(3, test_measure_linux_cpu_->get_current_state().id());
+
   ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(6, test_receive_measurements->GetNumReceived());
   // expectation is:

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -263,8 +263,8 @@ TEST_F(LinuxCpuMeasurementTestFixture, TestPublishMetricsMessage)
   std::promise<bool> empty_promise;
   std::shared_future<bool> dummy_future = empty_promise.get_future();
   rclcpp::executors::SingleThreadedExecutor ex;
-  ex.add_node(test_measure_linux_cpu_);
-  ex.add_node(test_receive_measurements);
+  ex.add_node(test_measure_linux_cpu_->get_node_base_interface());
+  ex.add_node(test_receive_measurements->get_node_base_interface());
 
   //
   // spin the node with it started

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -304,8 +304,8 @@ TEST_F(LinuxMemoryMeasurementTestFixture, TestPublishMetricsMessage)
   std::promise<bool> empty_promise;
   std::shared_future<bool> dummy_future = empty_promise.get_future();
   rclcpp::executors::SingleThreadedExecutor ex;
-  ex.add_node(test_measure_linux_memory_);
-  ex.add_node(test_receive_measurements);
+  ex.add_node(test_measure_linux_memory_->get_node_base_interface());
+  ex.add_node(test_receive_measurements->get_node_base_interface());
 
   //
   // spin the node with it started

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -283,8 +283,8 @@ TEST_F(LinuxProcessCpuMeasurementTestFixture, TestPublishMetricsMessage)
   std::promise<bool> empty_promise;
   std::shared_future<bool> dummy_future = empty_promise.get_future();
   rclcpp::executors::SingleThreadedExecutor ex;
-  ex.add_node(test_node_);
-  ex.add_node(test_receive_measurements);
+  ex.add_node(test_node_->get_node_base_interface());
+  ex.add_node(test_receive_measurements->get_node_base_interface());
 
   //
   // spin the node with it started

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -22,6 +22,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "lifecycle_msgs/msg/state.hpp"
+
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
 #include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
 
@@ -32,6 +34,7 @@
 
 #include "test_constants.hpp"
 
+using lifecycle_msgs::msg::State;
 using metrics_statistics_msgs::msg::MetricsMessage;
 using metrics_statistics_msgs::msg::StatisticDataPoint;
 using metrics_statistics_msgs::msg::StatisticDataType;
@@ -250,7 +253,7 @@ public:
   {
     test_node_->shutdown();
     EXPECT_FALSE(test_node_->IsStarted());
-    EXPECT_EQ(4, test_node_->get_current_state().id());
+    EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_node_->get_current_state().id());
 
     test_node_.reset();
     rclcpp::shutdown();
@@ -279,7 +282,7 @@ TEST_F(LinuxProcessCpuMeasurementTestFixture, TestPublishMetricsMessage)
 {
   ASSERT_NE(test_node_, nullptr);
   ASSERT_FALSE(test_node_->IsStarted());
-  ASSERT_EQ(1, test_node_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node_->get_current_state().id());
 
   auto test_receive_measurements = std::make_shared<TestReceiveProcessCpuMeasurementNode>(
     "test_receive_measurements", test_node_->GetMetricName());
@@ -293,11 +296,11 @@ TEST_F(LinuxProcessCpuMeasurementTestFixture, TestPublishMetricsMessage)
   // spin the node with it started
   //
   test_node_->configure();
-  ASSERT_EQ(2, test_node_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_node_->get_current_state().id());
 
   test_node_->activate();
   ASSERT_TRUE(test_node_->IsStarted());
-  ASSERT_EQ(3, test_node_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_node_->get_current_state().id());
 
   ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(3, test_receive_measurements->GetNumReceived());
@@ -324,7 +327,7 @@ TEST_F(LinuxProcessCpuMeasurementTestFixture, TestPublishMetricsMessage)
   //
   test_node_->deactivate();
   ASSERT_FALSE(test_node_->IsStarted());
-  ASSERT_EQ(2, test_node_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_node_->get_current_state().id());
 
 
   ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
@@ -344,7 +347,7 @@ TEST_F(LinuxProcessCpuMeasurementTestFixture, TestPublishMetricsMessage)
   //
   test_node_->activate();
   ASSERT_TRUE(test_node_->IsStarted());
-  ASSERT_EQ(3, test_node_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_node_->get_current_state().id());
 
   ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
   EXPECT_EQ(6, test_receive_measurements->GetNumReceived());

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -20,11 +20,15 @@
 #include <string>
 #include <vector>
 
+#include "lifecycle_msgs/msg/state.hpp"
+
 #include "../../src/system_metrics_collector/constants.hpp"
 #include "../../src/system_metrics_collector/linux_process_memory_measurement_node.hpp"
 #include "../../src/system_metrics_collector/utilities.hpp"
 
 #include "test_constants.hpp"
+
+using lifecycle_msgs::msg::State;
 
 namespace
 {
@@ -67,6 +71,7 @@ public:
       "test_periodic_node", options);
 
     ASSERT_FALSE(test_node_->IsStarted());
+    ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node_->get_current_state().id());
 
     const moving_average_statistics::StatisticData data =
       test_node_->GetStatisticsResults();
@@ -80,7 +85,9 @@ public:
   void TearDown() override
   {
     test_node_->shutdown();
-    ASSERT_FALSE(test_node_->IsStarted());
+    EXPECT_FALSE(test_node_->IsStarted());
+    EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_node_->get_current_state().id());
+
     test_node_.reset();
     rclcpp::shutdown();
   }

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -79,7 +79,7 @@ public:
 
   void TearDown() override
   {
-    test_node_->Stop();
+    test_node_->shutdown();
     ASSERT_FALSE(test_node_->IsStarted());
     test_node_.reset();
     rclcpp::shutdown();
@@ -88,7 +88,6 @@ public:
 protected:
   std::shared_ptr<TestLinuxProcessMemoryMeasurementNode> test_node_;
 };
-
 
 TEST(TestLinuxProcessMemoryMeasurement, TestGetProcessUsedMemory) {
   EXPECT_THROW(system_metrics_collector::GetProcessUsedMemory(

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -57,6 +57,16 @@ public:
     return times_published_;
   }
 
+  /**
+   * Return true if the lifecycle publisher is activated, false if null or not activated.
+   *
+   * @return
+   */
+  bool IsPublisherActivated() const
+  {
+    return !(publisher_ == nullptr || !publisher_->is_activated());
+  }
+
 private:
   /**
    * Test measurement for the fixture.
@@ -110,6 +120,7 @@ public:
       kTestNodeName, options);
 
     ASSERT_FALSE(test_periodic_measurer_->IsStarted());
+    ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
     const moving_average_statistics::StatisticData data =
       test_periodic_measurer_->GetStatisticsResults();
@@ -125,6 +136,7 @@ public:
     test_periodic_measurer_->shutdown();
     EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_periodic_measurer_->get_current_state().id());
     EXPECT_FALSE(test_periodic_measurer_->IsStarted());
+    EXPECT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
     test_periodic_measurer_.reset();
     rclcpp::shutdown();
@@ -157,14 +169,17 @@ TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
   ASSERT_NE(test_periodic_measurer_, nullptr);
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_periodic_measurer_->get_current_state().id());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
   test_periodic_measurer_->configure();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
 
   test_periodic_measurer_->activate();
   ASSERT_TRUE(test_periodic_measurer_->IsStarted());
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_periodic_measurer_->get_current_state().id());
+  ASSERT_TRUE(test_periodic_measurer_->IsPublisherActivated());
 
   std::promise<bool> empty_promise;
   std::shared_future<bool> dummy_future = empty_promise.get_future();
@@ -186,6 +201,7 @@ TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
   test_periodic_measurer_->deactivate();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
   int times_published = test_periodic_measurer_->GetNumPublished();
   ASSERT_EQ(
@@ -196,21 +212,25 @@ TEST_F(PeriodicMeasurementTestFixure, TestLifecycleManually) {
   ASSERT_NE(test_periodic_measurer_, nullptr);
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_periodic_measurer_->get_current_state().id());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
   // configure the node
   test_periodic_measurer_->configure();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
   // activate the node
   test_periodic_measurer_->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_TRUE(test_periodic_measurer_->IsStarted());
+  ASSERT_TRUE(test_periodic_measurer_->IsPublisherActivated());
 
   // deactivate the node
   test_periodic_measurer_->deactivate();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
   // shutdown happens in teardown
 }
@@ -218,23 +238,26 @@ TEST_F(PeriodicMeasurementTestFixure, TestLifecycleManually) {
 TEST_F(PeriodicMeasurementTestFixure, TestLifecycleManually_reactivate) {
   ASSERT_NE(test_periodic_measurer_, nullptr);
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
-
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_periodic_measurer_->get_current_state().id());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
   // configure the node
   test_periodic_measurer_->configure();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
   // activate the node
   test_periodic_measurer_->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_TRUE(test_periodic_measurer_->IsStarted());
+  ASSERT_TRUE(test_periodic_measurer_->IsPublisherActivated());
 
   // deactivate the node
   test_periodic_measurer_->deactivate();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
+  ASSERT_FALSE(test_periodic_measurer_->IsPublisherActivated());
 
   // reactivate the node
   test_periodic_measurer_->activate();

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -64,7 +64,7 @@ public:
    */
   bool IsPublisherActivated() const
   {
-    return !(publisher_ == nullptr || !publisher_->is_activated());
+    return publisher_ != nullptr && publisher_->is_activated();
   }
 
 private:

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -25,11 +25,15 @@
 #include <vector>
 
 #include "../../src/moving_average_statistics/types.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+
 #include "../../src/system_metrics_collector/collector.hpp"
 #include "../../src/system_metrics_collector/constants.hpp"
 #include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
 
 #include "test_constants.hpp"
+
+using lifecycle_msgs::msg::State;
 
 namespace
 {
@@ -152,15 +156,15 @@ TEST_F(PeriodicMeasurementTestFixure, Sanity) {
 TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
   ASSERT_NE(test_periodic_measurer_, nullptr);
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
-  ASSERT_EQ(1, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_periodic_measurer_->get_current_state().id());
 
   test_periodic_measurer_->configure();
-  ASSERT_EQ(2, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
 
 
   test_periodic_measurer_->activate();
   ASSERT_TRUE(test_periodic_measurer_->IsStarted());
-  ASSERT_EQ(3, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_periodic_measurer_->get_current_state().id());
 
   std::promise<bool> empty_promise;
   std::shared_future<bool> dummy_future = empty_promise.get_future();
@@ -180,7 +184,7 @@ TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
     data.sample_count);
 
   test_periodic_measurer_->deactivate();
-  ASSERT_EQ(2, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
 
   int times_published = test_periodic_measurer_->GetNumPublished();
@@ -191,59 +195,53 @@ TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
 TEST_F(PeriodicMeasurementTestFixure, TestLifecycleManually) {
   ASSERT_NE(test_periodic_measurer_, nullptr);
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
-  ASSERT_EQ(1, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_periodic_measurer_->get_current_state().id());
 
   // configure the node
   test_periodic_measurer_->configure();
-  ASSERT_EQ(2, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
 
   // activate the node
   test_periodic_measurer_->activate();
-  ASSERT_EQ(3, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_TRUE(test_periodic_measurer_->IsStarted());
 
   // deactivate the node
   test_periodic_measurer_->deactivate();
-  ASSERT_EQ(2, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
 
-  // shutdown the node
-  test_periodic_measurer_->shutdown();
-  ASSERT_EQ(4, test_periodic_measurer_->get_current_state().id());
-  ASSERT_FALSE(test_periodic_measurer_->IsStarted());
+  // shutdown happens in teardown
 }
 
 TEST_F(PeriodicMeasurementTestFixure, TestLifecycleManually_reactivate) {
   ASSERT_NE(test_periodic_measurer_, nullptr);
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
 
-  ASSERT_EQ(1, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_periodic_measurer_->get_current_state().id());
 
   // configure the node
   test_periodic_measurer_->configure();
-  ASSERT_EQ(2, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
 
   // activate the node
   test_periodic_measurer_->activate();
-  ASSERT_EQ(3, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_TRUE(test_periodic_measurer_->IsStarted());
 
   // deactivate the node
   test_periodic_measurer_->deactivate();
-  ASSERT_EQ(2, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_FALSE(test_periodic_measurer_->IsStarted());
 
   // reactivate the node
   test_periodic_measurer_->activate();
-  ASSERT_EQ(3, test_periodic_measurer_->get_current_state().id());
+  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_periodic_measurer_->get_current_state().id());
   ASSERT_TRUE(test_periodic_measurer_->IsStarted());
 
-  // shutdown the node
-  test_periodic_measurer_->shutdown();
-  ASSERT_EQ(4, test_periodic_measurer_->get_current_state().id());
-  ASSERT_FALSE(test_periodic_measurer_->IsStarted());
+  // shutdown happens in teardown
 }
 
 TEST_F(PeriodicMeasurementTestFixure, TestConstructorMeasurementPeriodValidation) {

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -158,7 +158,7 @@ TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
   std::shared_future<bool> dummy_future = empty_promise.get_future();
 
   rclcpp::executors::SingleThreadedExecutor ex;
-  ex.add_node(test_periodic_measurer_);
+  ex.add_node(test_periodic_measurer_->get_node_base_interface());
   ex.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
 
   moving_average_statistics::StatisticData data = test_periodic_measurer_->GetStatisticsResults();


### PR DESCRIPTION
Inherit from LifecycleNode in order to use the existing state machine for a user to start and stop collection. This PR does the following:

- refactor PeriodicMeasurementNode to inherit from LifecycleNode
- refactor unit tests to manually call lifecycle transitions
- refactor launch entry points to automatically activate and shutdown