### PR TITLE
Use rclcpp::NodeOptions during node construction

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/constants.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/constants.hpp
@@ -15,7 +15,6 @@
 #ifndef SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_
 #define SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_
 
-#include <chrono>
 
 namespace system_metrics_collector
 {
@@ -24,8 +23,12 @@ namespace collector_node_constants
 {
 
 constexpr const char kStatisticsTopicName[] = "system_metrics";
-constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
-constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
+
+constexpr const char kCollectPeriodParam[] = "measurement_period";
+constexpr const int64_t kDefaultCollectPeriodInMs = 1000;   // 1 second
+
+constexpr const char kPublishPeriodParam[] = "publish_period";
+constexpr const int64_t kDefaultPublishPeriodInMs = 60000;  // 1 minute
 
 }  // namespace collector_node_constants
 

--- a/system_metrics_collector/src/system_metrics_collector/constants.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/constants.hpp
@@ -15,6 +15,7 @@
 #ifndef SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_
 #define SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_
 
+#include <chrono>
 
 namespace system_metrics_collector
 {
@@ -25,10 +26,11 @@ namespace collector_node_constants
 constexpr const char kStatisticsTopicName[] = "system_metrics";
 
 constexpr const char kCollectPeriodParam[] = "measurement_period";
-constexpr const int64_t kDefaultCollectPeriodInMs = 1000;   // 1 second
+constexpr const std::chrono::milliseconds kDefaultCollectPeriod{1000};    // 1 second
 
 constexpr const char kPublishPeriodParam[] = "publish_period";
-constexpr const int64_t kDefaultPublishPeriodInMs = 60000;  // 1 minute
+constexpr const std::chrono::milliseconds kDefaultPublishPeriod{60000};   // 1 minute
+
 
 }  // namespace collector_node_constants
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
@@ -31,9 +31,7 @@ int main(int argc, char ** argv)
 
   const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
     "linuxCpuCollector",
-    system_metrics_collector::collector_node_constants::kDefaultCollectPeriod,
-    system_metrics_collector::collector_node_constants::kStatisticsTopicName,
-    system_metrics_collector::collector_node_constants::kDefaultPublishPeriod);
+    rclcpp::NodeOptions());
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
@@ -30,8 +30,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
-    "linuxCpuCollector",
-    rclcpp::NodeOptions());
+    "linuxCpuCollector");
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_collector.cpp
@@ -29,8 +29,8 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
-    "linuxCpuCollector");
+  const auto cpu_node =
+    std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>("linuxCpuCollector");
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -39,8 +39,9 @@ namespace system_metrics_collector
 LinuxCpuMeasurementNode::LinuxCpuMeasurementNode(
   const std::string & name,
   const rclcpp::NodeOptions & options)
-: PeriodicMeasurementNode(name, options)
-{}
+: PeriodicMeasurementNode{name, options}
+{
+}
 
 bool LinuxCpuMeasurementNode::SetupStart()
 {

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -38,10 +38,8 @@ namespace system_metrics_collector
 
 LinuxCpuMeasurementNode::LinuxCpuMeasurementNode(
   const std::string & name,
-  const std::chrono::milliseconds measurement_period,
-  const std::string & topic,
-  const std::chrono::milliseconds publish_period)
-: PeriodicMeasurementNode(name, measurement_period, topic, publish_period)
+  const rclcpp::NodeOptions & options)
+: PeriodicMeasurementNode(name, options)
 {}
 
 bool LinuxCpuMeasurementNode::SetupStart()

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -44,7 +44,7 @@ public:
    */
   LinuxCpuMeasurementNode(
     const std::string & name,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions{});
 
   virtual ~LinuxCpuMeasurementNode() = default;
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -37,7 +37,7 @@ public:
    * Construct a LinuxCpuMeasurementNode.
    * The following parameters may be set via the rclcpp::NodeOptions:
    * `measurement_period`: the period of this node, used to read measurements
-   * `publish_period`: the period at which metrics are published. 0 ms means don't publish
+   * `publish_period`: the period at which metrics are published
    *
    * @param name the name of this node
    * @param options the options (arguments, parameters, etc.) for this node

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -34,14 +34,17 @@ class LinuxCpuMeasurementNode : public system_metrics_collector::PeriodicMeasure
 {
 public:
   /**
-   * Construct a LinuxCpuMeasurementNode
+   * Construct a LinuxCpuMeasurementNode.
+   * The following parameters may be set via the rclcpp::NodeOptions:
+   * `measurement_period`: the period of this node, used to read measurements
+   * `publish_period`: the period at which metrics are published. 0 ms means don't publish
    *
    * @param name the name of this node
-   * @param measurement_period the period of this node, used to read measurements
-   * @param topic the topic name used for publishing
-   * @param publish_period the period at which metrics are published. 0 ms means don't publish
+   * @param options the options (arguments, parameters, etc.) for this node
    */
-  LinuxCpuMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
+  LinuxCpuMeasurementNode(
+    const std::string & name,
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   virtual ~LinuxCpuMeasurementNode() = default;
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -41,11 +41,7 @@ public:
    * @param topic the topic name used for publishing
    * @param publish_period the period at which metrics are published. 0 ms means don't publish
    */
-  LinuxCpuMeasurementNode(
-    const std::string & name,
-    const std::chrono::milliseconds measurement_period,
-    const std::string & topic,
-    const std::chrono::milliseconds publish_period);
+  LinuxCpuMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
 
   virtual ~LinuxCpuMeasurementNode() = default;
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
@@ -28,7 +28,8 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
+  const auto mem_node =
+    std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector");
 
   rclcpp::executors::MultiThreadedExecutor ex;

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
@@ -30,9 +30,7 @@ int main(int argc, char ** argv)
 
   const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector",
-    system_metrics_collector::collector_node_constants::kDefaultCollectPeriod,
-    system_metrics_collector::collector_node_constants::kStatisticsTopicName,
-    system_metrics_collector::collector_node_constants::kDefaultPublishPeriod);
+    rclcpp::NodeOptions());
 
   rclcpp::executors::MultiThreadedExecutor ex;
   mem_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_collector.cpp
@@ -29,8 +29,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
-    "linuxMemoryCollector",
-    rclcpp::NodeOptions());
+    "linuxMemoryCollector");
 
   rclcpp::executors::MultiThreadedExecutor ex;
   mem_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -38,10 +38,8 @@ namespace system_metrics_collector
 
 LinuxMemoryMeasurementNode::LinuxMemoryMeasurementNode(
   const std::string & name,
-  const std::chrono::milliseconds measurement_period,
-  const std::string & topic,
-  const std::chrono::milliseconds publish_period)
-: PeriodicMeasurementNode(name, measurement_period, topic, publish_period)
+  const rclcpp::NodeOptions & options)
+: PeriodicMeasurementNode(name, options)
 {
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -39,7 +39,7 @@ namespace system_metrics_collector
 LinuxMemoryMeasurementNode::LinuxMemoryMeasurementNode(
   const std::string & name,
   const rclcpp::NodeOptions & options)
-: PeriodicMeasurementNode(name, options)
+: PeriodicMeasurementNode{name, options}
 {
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -32,13 +32,16 @@ class LinuxMemoryMeasurementNode : public system_metrics_collector::PeriodicMeas
 public:
   /**
    * Construct a LinuxMemoryMeasurementNode
+   * The following parameters may be set via the rclcpp::NodeOptions:
+   * `measurement_period`: the period of this node, used to read measurements
+   * `publish_period`: the period at which metrics are published
    *
    * @param name the name of this node
-   * @param measurement_period the period of this node, used to read measurements
-   * @param topic the topic name used for publishing
-   * @param publish_period the period at which metrics are published. 0 ms means don't publish
+   * @param options the options (arguments, parameters, etc.) for this node
    */
-  LinuxMemoryMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
+  LinuxMemoryMeasurementNode(
+    const std::string & name,
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   virtual ~LinuxMemoryMeasurementNode() = default;
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -38,11 +38,7 @@ public:
    * @param topic the topic name used for publishing
    * @param publish_period the period at which metrics are published. 0 ms means don't publish
    */
-  LinuxMemoryMeasurementNode(
-    const std::string & name,
-    const std::chrono::milliseconds measurement_period,
-    const std::string & topic,
-    const std::chrono::milliseconds publish_period);
+  LinuxMemoryMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
 
   virtual ~LinuxMemoryMeasurementNode() = default;
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -41,7 +41,7 @@ public:
    */
   LinuxMemoryMeasurementNode(
     const std::string & name,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions{});
 
   virtual ~LinuxMemoryMeasurementNode() = default;
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -42,8 +42,8 @@ namespace system_metrics_collector
 LinuxProcessCpuMeasurementNode::LinuxProcessCpuMeasurementNode(
   const std::string & name,
   const rclcpp::NodeOptions & options)
-: PeriodicMeasurementNode(name, options),
-  metric_name_(std::to_string(GetPid()) + kMetricName)
+: PeriodicMeasurementNode{name, options},
+  metric_name_{std::to_string(GetPid()) + kMetricName}
 {
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -40,7 +40,7 @@ namespace system_metrics_collector
 {
 
 LinuxProcessCpuMeasurementNode::LinuxProcessCpuMeasurementNode(
-  const std::string & name, 
+  const std::string & name,
   const rclcpp::NodeOptions & options)
 : PeriodicMeasurementNode(name, options),
   metric_name_(std::to_string(GetPid()) + kMetricName)

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -40,11 +40,9 @@ namespace system_metrics_collector
 {
 
 LinuxProcessCpuMeasurementNode::LinuxProcessCpuMeasurementNode(
-  const std::string & name,
-  const std::chrono::milliseconds measurement_period,
-  const std::string & topic,
-  const std::chrono::milliseconds publish_period)
-: PeriodicMeasurementNode(name, measurement_period, topic, publish_period),
+  const std::string & name, 
+  const rclcpp::NodeOptions & options)
+: PeriodicMeasurementNode(name, options),
   metric_name_(std::to_string(GetPid()) + kMetricName)
 {
 }

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -39,13 +39,16 @@ class LinuxProcessCpuMeasurementNode : public PeriodicMeasurementNode
 public:
   /**
    * Constructs a LinuxProcessCpuMeasurementNode.
+   * The following parameters may be set via the rclcpp::NodeOptions:
+   * `measurement_period`: the period of this node, used to read measurements
+   * `publish_period`: the period at which metrics are published
    *
    * @param name the name of this node
-   * @param measurement_period the period of this node, used to read measurements
-   * @param topic the topic name used for publishing
-   * @param publish_period the period at which metrics are published.
+   * @param options the options (arguments, parameters, etc.) for this node
    */
-  LinuxProcessCpuMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
+  LinuxProcessCpuMeasurementNode(
+    const std::string & name,
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
 protected:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -45,11 +45,7 @@ public:
    * @param topic the topic name used for publishing
    * @param publish_period the period at which metrics are published.
    */
-  LinuxProcessCpuMeasurementNode(
-    const std::string & name,
-    const std::chrono::milliseconds measurement_period,
-    const std::string & topic,
-    const std::chrono::milliseconds publish_period);
+  LinuxProcessCpuMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
 
 protected:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -48,7 +48,7 @@ public:
    */
   LinuxProcessCpuMeasurementNode(
     const std::string & name,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions{});
 
 protected:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -52,10 +52,8 @@ namespace system_metrics_collector
 
 LinuxProcessMemoryMeasurementNode::LinuxProcessMemoryMeasurementNode(
   const std::string & name,
-  const std::chrono::milliseconds measurement_period,
-  const std::string & topic,
-  const std::chrono::milliseconds publish_period)
-: PeriodicMeasurementNode(name, measurement_period, topic, publish_period),
+  const rclcpp::NodeOptions & options)
+: PeriodicMeasurementNode(name, options),
   pid_(std::to_string(GetPid())),
   file_to_read_(kProc + std::to_string(GetPid()) + kStatm)
 {

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -53,9 +53,9 @@ namespace system_metrics_collector
 LinuxProcessMemoryMeasurementNode::LinuxProcessMemoryMeasurementNode(
   const std::string & name,
   const rclcpp::NodeOptions & options)
-: PeriodicMeasurementNode(name, options),
-  pid_(std::to_string(GetPid())),
-  file_to_read_(kProc + std::to_string(GetPid()) + kStatm)
+: PeriodicMeasurementNode{name, options},
+  pid_{std::to_string(GetPid())},
+  file_to_read_{kProc + std::to_string(GetPid()) + kStatm}
 {
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -46,13 +46,16 @@ class LinuxProcessMemoryMeasurementNode : public PeriodicMeasurementNode
 public:
   /**
    * Construct a LinuxProcessMemoryMeasurementNode
+   * The following parameters may be set via the rclcpp::NodeOptions:
+   * `measurement_period`: the period of this node, used to read measurements
+   * `publish_period`: the period at which metrics are published
    *
    * @param name the name of this node
-   * @param measurement_period the period of this node, used to read measurements
-   * @param topic the topic name used for publishing
-   * @param publish_period the period at which metrics are published.
+   * @param options the options (arguments, parameters, etc.) for this node
    */
-  LinuxProcessMemoryMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
+  LinuxProcessMemoryMeasurementNode(
+    const std::string & name,
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
 protected:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -52,11 +52,7 @@ public:
    * @param topic the topic name used for publishing
    * @param publish_period the period at which metrics are published.
    */
-  LinuxProcessMemoryMeasurementNode(
-    const std::string & name,
-    const std::chrono::milliseconds measurement_period,
-    const std::string & topic,
-    const std::chrono::milliseconds publish_period);
+  LinuxProcessMemoryMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
 
 protected:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -55,7 +55,7 @@ public:
    */
   LinuxProcessMemoryMeasurementNode(
     const std::string & name,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions{});
 
 protected:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -27,12 +27,6 @@
 #include "../../src/system_metrics_collector/linux_process_cpu_measurement_node.hpp"
 #include "../../src/system_metrics_collector/linux_process_memory_measurement_node.hpp"
 
-namespace
-{
-constexpr const char kStatisticsTopicName[] = "system_metrics";
-constexpr const std::chrono::seconds kDefaultCollectPeriod{1};
-constexpr const std::chrono::minutes kDefaultPublishPeriod{1};
-}  // namespace
 
 void set_node_to_debug(
   const system_metrics_collector::PeriodicMeasurementNode * node,
@@ -59,29 +53,21 @@ int main(int argc, char ** argv)
   using namespace std::chrono_literals;
   const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
     "linuxCpuCollector",
-    kDefaultCollectPeriod,
-    kStatisticsTopicName,
-    kDefaultPublishPeriod);
+    rclcpp::NodeOptions());
 
   const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
     "linuxMemoryCollector",
-    kDefaultCollectPeriod,
-    kStatisticsTopicName,
-    kDefaultPublishPeriod);
+    rclcpp::NodeOptions());
 
   const auto process_cpu_node =
     std::make_shared<system_metrics_collector::LinuxProcessCpuMeasurementNode>(
     "linuxProcessCpuCollector",
-    kDefaultCollectPeriod,
-    kStatisticsTopicName,
-    kDefaultPublishPeriod);
+    rclcpp::NodeOptions());
 
   const auto process_mem_node =
     std::make_shared<system_metrics_collector::LinuxProcessMemoryMeasurementNode>(
     "linuxProcessMemoryCollector",
-    kDefaultCollectPeriod,
-    kStatisticsTopicName,
-    kDefaultPublishPeriod);
+    rclcpp::NodeOptions());
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -51,11 +51,11 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   using namespace std::chrono_literals;
-  const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
-    "linuxCpuCollector");
+  const auto cpu_node =
+    std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>("linuxCpuCollector");
 
-  const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
-    "linuxMemoryCollector");
+  const auto mem_node =
+    std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>("linuxMemoryCollector");
 
   const auto process_cpu_node =
     std::make_shared<system_metrics_collector::LinuxProcessCpuMeasurementNode>(

--- a/system_metrics_collector/src/system_metrics_collector/main.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/main.cpp
@@ -52,22 +52,18 @@ int main(int argc, char ** argv)
 
   using namespace std::chrono_literals;
   const auto cpu_node = std::make_shared<system_metrics_collector::LinuxCpuMeasurementNode>(
-    "linuxCpuCollector",
-    rclcpp::NodeOptions());
+    "linuxCpuCollector");
 
   const auto mem_node = std::make_shared<system_metrics_collector::LinuxMemoryMeasurementNode>(
-    "linuxMemoryCollector",
-    rclcpp::NodeOptions());
+    "linuxMemoryCollector");
 
   const auto process_cpu_node =
     std::make_shared<system_metrics_collector::LinuxProcessCpuMeasurementNode>(
-    "linuxProcessCpuCollector",
-    rclcpp::NodeOptions());
+    "linuxProcessCpuCollector");
 
   const auto process_mem_node =
     std::make_shared<system_metrics_collector::LinuxProcessMemoryMeasurementNode>(
-    "linuxProcessMemoryCollector",
-    rclcpp::NodeOptions());
+    "linuxProcessMemoryCollector");
 
   rclcpp::executors::MultiThreadedExecutor ex;
   cpu_node->Start();

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -16,9 +16,11 @@
 #include "periodic_measurement_node.hpp"
 
 #include <chrono>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
+#include "constants.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 using metrics_statistics_msgs::msg::MetricsMessage;
@@ -28,33 +30,48 @@ namespace system_metrics_collector
 
 PeriodicMeasurementNode::PeriodicMeasurementNode(
   const std::string & name,
-  const std::chrono::milliseconds measurement_period,
-  const std::string & publishing_topic,
-  const std::chrono::milliseconds publish_period)
-: Node(name),
-  measurement_period_(measurement_period),
-  publishing_topic_(publishing_topic),
-  measurement_timer_(nullptr),
-  publish_timer_(nullptr),
-  publish_period_(publish_period)
+  const rclcpp::NodeOptions & options)
+: Node(name, options)
 {
+  rcl_interfaces::msg::IntegerRange positive_range;
+  positive_range.from_value = 1;
+  positive_range.to_value = std::numeric_limits<decltype(rcl_interfaces::msg::IntegerRange::to_value)>::max();
+  positive_range.step = 1;
+
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.read_only = true;
+  descriptor.integer_range.push_back(positive_range);
+
   // rclcpp::Node throws if name is empty
 
-  if (measurement_period <= std::chrono::milliseconds{0}) {
+  descriptor.description = "The period between each measurement";
+  auto measurement_period = declare_parameter(
+    collector_node_constants::kCollectPeriodParam, 
+    collector_node_constants::kDefaultCollectPeriodInMs, 
+    descriptor);
+  measurement_period_ = std::chrono::milliseconds{measurement_period};
+  if (measurement_period_ <= std::chrono::milliseconds{0}) {
     throw std::invalid_argument{"measurement_period cannot be negative"};
   }
 
-  if (publishing_topic.empty()) {
-    throw std::invalid_argument{"publishing_topic cannot be empty"};
-  }
-
-  if (publish_period <= std::chrono::milliseconds{0}) {
+  descriptor.description = "The period between each published MetricsMessage";
+  auto publish_period = declare_parameter(
+    collector_node_constants::kPublishPeriodParam, 
+    collector_node_constants::kDefaultPublishPeriodInMs, 
+    descriptor);
+  publish_period_ = std::chrono::milliseconds{publish_period};
+  if (publish_period_ <= std::chrono::milliseconds{0}) {
     throw std::invalid_argument{"publish_period cannot be negative"};
   }
 
-  if (publish_period <= measurement_period) {
+  if (publish_period_ <= measurement_period_) {
     throw std::invalid_argument{
-            "publish_period cannot be less than or equal to the measurement_period"};
+      "publish_period cannot be less than or equal to the measurement_period"};
+  }
+
+  publishing_topic_ = collector_node_constants::kStatisticsTopicName;
+  if (publishing_topic_.empty()) {
+    throw std::invalid_argument{"publishing_topic cannot be empty"};
   }
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -112,7 +112,7 @@ std::string PeriodicMeasurementNode::GetStatusString() const
   std::stringstream ss;
   ss << "name=" << get_name() <<
     ", measurement_period=" << std::to_string(measurement_period_.count()) << "ms" <<
-    ", publishing_topic=" << ((publisher_ == nullptr) ? "" : publisher_->get_topic_name()) <<
+    ", publishing_topic=" << (publisher_ ? publisher_->get_topic_name() : "") <<
     ", publish_period=" << std::to_string(publish_period_.count()) + "ms" <<
     ", " << Collector::GetStatusString();
   return ss.str();

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -122,7 +122,7 @@ std::string PeriodicMeasurementNode::GetStatusString() const
   std::stringstream ss;
   ss << "name=" << get_name() <<
     ", measurement_period=" << std::to_string(measurement_period_.count()) << "ms" <<
-    ", publishing_topic=" << publishing_topic_ <<
+    ", publishing_topic=" << ((publisher_ == nullptr) ? "" : publisher_->get_topic_name()) <<
     ", publish_period=" << std::to_string(publish_period_.count()) + "ms" <<
     ", " << Collector::GetStatusString();
   return ss.str();

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -44,7 +44,7 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
 
   // rclcpp::Node throws if name is empty
 
-  descriptor.description = "The period between each measurement";
+  descriptor.description = "The period in milliseconds between each measurement";
   auto measurement_period = declare_parameter(
     collector_node_constants::kCollectPeriodParam, 
     collector_node_constants::kDefaultCollectPeriodInMs, 
@@ -54,7 +54,7 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
     throw std::invalid_argument{"measurement_period cannot be negative"};
   }
 
-  descriptor.description = "The period between each published MetricsMessage";
+  descriptor.description = "The period in milliseconds between each published MetricsMessage";
   auto publish_period = declare_parameter(
     collector_node_constants::kPublishPeriodParam, 
     collector_node_constants::kDefaultPublishPeriodInMs, 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -48,14 +48,14 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
   descriptor.description = "The period in milliseconds between each measurement";
   auto measurement_period = declare_parameter(
     collector_node_constants::kCollectPeriodParam,
-    collector_node_constants::kDefaultCollectPeriodInMs,
+    collector_node_constants::kDefaultCollectPeriod.count(),
     descriptor);
   measurement_period_ = std::chrono::milliseconds{measurement_period};
 
   descriptor.description = "The period in milliseconds between each published MetricsMessage";
   auto publish_period = declare_parameter(
     collector_node_constants::kPublishPeriodParam,
-    collector_node_constants::kDefaultPublishPeriodInMs,
+    collector_node_constants::kDefaultPublishPeriod.count(),
     descriptor);
   publish_period_ = std::chrono::milliseconds{publish_period};
 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -35,7 +35,8 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
 {
   rcl_interfaces::msg::IntegerRange positive_range;
   positive_range.from_value = 1;
-  positive_range.to_value = std::numeric_limits<decltype(rcl_interfaces::msg::IntegerRange::to_value)>::max();
+  positive_range.to_value =
+    std::numeric_limits<decltype(rcl_interfaces::msg::IntegerRange::to_value)>::max();
   positive_range.step = 1;
 
   rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -46,8 +47,8 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
 
   descriptor.description = "The period in milliseconds between each measurement";
   auto measurement_period = declare_parameter(
-    collector_node_constants::kCollectPeriodParam, 
-    collector_node_constants::kDefaultCollectPeriodInMs, 
+    collector_node_constants::kCollectPeriodParam,
+    collector_node_constants::kDefaultCollectPeriodInMs,
     descriptor);
   measurement_period_ = std::chrono::milliseconds{measurement_period};
   if (measurement_period_ <= std::chrono::milliseconds{0}) {
@@ -56,8 +57,8 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
 
   descriptor.description = "The period in milliseconds between each published MetricsMessage";
   auto publish_period = declare_parameter(
-    collector_node_constants::kPublishPeriodParam, 
-    collector_node_constants::kDefaultPublishPeriodInMs, 
+    collector_node_constants::kPublishPeriodParam,
+    collector_node_constants::kDefaultPublishPeriodInMs,
     descriptor);
   publish_period_ = std::chrono::milliseconds{publish_period};
   if (publish_period_ <= std::chrono::milliseconds{0}) {
@@ -66,7 +67,7 @@ PeriodicMeasurementNode::PeriodicMeasurementNode(
 
   if (publish_period_ <= measurement_period_) {
     throw std::invalid_argument{
-      "publish_period cannot be less than or equal to the measurement_period"};
+            "publish_period cannot be less than or equal to the measurement_period"};
   }
 
   publishing_topic_ = collector_node_constants::kStatisticsTopicName;

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -38,12 +38,12 @@ class PeriodicMeasurementNode : public system_metrics_collector::Collector,
 public:
   /**
    * Construct a PeriodicMeasurementNode.
+   * The following parameters may be set via the rclcpp::NodeOptions:
+   * `measurement_period`: the period of this node, used to read measurements
+   * `publish_period`: the period at which metrics are published
    *
    * @param name the name of this node. This must be non-empty.
-   * @param topic the topic for publishing data. This must be non-empty.
-   * @param measurement_period. This must be non-negative and strictly less than publish_period.
-   * @param publish_period the window of active measurements. This must be non-negative and
-   * strictly greater than measurement_period.
+   * @param options the options (arguments, parameters, etc.) for this node
    * @throws std::invalid_argument for any invalid input
    */
   PeriodicMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
@@ -101,10 +101,6 @@ private:
    */
   void PublishStatisticMessage() override;
 
-  /**
-   * Topic used for publishing
-   */
-  std::string publishing_topic_;
   /**
    * The period used to take a single measurement
    */

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -46,11 +46,7 @@ public:
    * strictly greater than measurement_period.
    * @throws std::invalid_argument for any invalid input
    */
-  PeriodicMeasurementNode(
-    const std::string & name,
-    const std::chrono::milliseconds measurement_period,
-    const std::string & publishing_topic,  // todo @dbbonnie think about a default topic
-    const std::chrono::milliseconds publish_period);
+  PeriodicMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options);
 
   virtual ~PeriodicMeasurementNode() = default;
 
@@ -108,15 +104,15 @@ private:
   /**
    * Topic used for publishing
    */
-  const std::string publishing_topic_;
+  std::string publishing_topic_;
   /**
    * The period used to take a single measurement
    */
-  const std::chrono::milliseconds measurement_period_;
+  std::chrono::milliseconds measurement_period_;
   /**
    * The period used to publish measurement data
    */
-  const std::chrono::milliseconds publish_period_;
+  std::chrono::milliseconds publish_period_;
 
   rclcpp::TimerBase::SharedPtr measurement_timer_;
   rclcpp::TimerBase::SharedPtr publish_timer_;

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -52,7 +52,7 @@ class TestLinuxCpuMeasurementNode : public system_metrics_collector::LinuxCpuMea
 {
 public:
   TestLinuxCpuMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options)
-  : LinuxCpuMeasurementNode(name, options) {}
+  : LinuxCpuMeasurementNode{name, options} {}
 
   ~TestLinuxCpuMeasurementNode() override = default;
 

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
 #include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
@@ -217,9 +218,9 @@ public:
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       test_constants::kPublishPeriod.count());
 
-    std::vector<std::string> arguments = { "--ros-args", "--remap", std::string(
-      system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=" + kTestTopic };
+    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
+        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
+      ":=" + kTestTopic};
     options.arguments(arguments);
 
     test_measure_linux_cpu_ = std::make_shared<TestLinuxCpuMeasurementNode>(

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -26,6 +26,7 @@
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
 #include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
 
+#include "../../src/system_metrics_collector/constants.hpp"
 #include "../../src/system_metrics_collector/linux_cpu_measurement_node.hpp"
 #include "../../src/system_metrics_collector/proc_cpu_data.hpp"
 #include "../../src/system_metrics_collector/utilities.hpp"
@@ -50,12 +51,8 @@ constexpr const char kTestMetricName[] = "system_cpu_percent_used";
 class TestLinuxCpuMeasurementNode : public system_metrics_collector::LinuxCpuMeasurementNode
 {
 public:
-  TestLinuxCpuMeasurementNode(
-    const std::string & name,
-    const std::chrono::milliseconds measurement_period,
-    const std::string & publishing_topic,
-    const std::chrono::milliseconds publish_period)
-  : LinuxCpuMeasurementNode(name, measurement_period, publishing_topic, publish_period) {}
+  TestLinuxCpuMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options)
+  : LinuxCpuMeasurementNode(name, options) {}
 
   ~TestLinuxCpuMeasurementNode() override = default;
 
@@ -212,8 +209,21 @@ public:
   {
     rclcpp::init(0, nullptr);
 
-    test_measure_linux_cpu_ = std::make_shared<TestLinuxCpuMeasurementNode>(kTestNodeName,
-        test_constants::kMeasurePeriod, kTestTopic, test_constants::kPublishPeriod);
+    rclcpp::NodeOptions options;
+    options.append_parameter_override(
+      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+      test_constants::kMeasurePeriod.count());
+    options.append_parameter_override(
+      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+      test_constants::kPublishPeriod.count());
+
+    std::vector<std::string> arguments = { "--ros-args", "--remap", std::string(
+      system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
+      ":=" + kTestTopic };
+    options.arguments(arguments);
+
+    test_measure_linux_cpu_ = std::make_shared<TestLinuxCpuMeasurementNode>(
+      kTestNodeName, options);
 
     ASSERT_FALSE(test_measure_linux_cpu_->IsStarted());
 

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -44,7 +44,6 @@ using test_constants::kProcSamples;
 namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_cpu";
-constexpr const char kTestTopic[] = "test_cpu_measure_topic";
 constexpr const char kTestMetricName[] = "system_cpu_percent_used";
 }  // namespace
 
@@ -81,7 +80,9 @@ public:
   {
     auto callback = [this](MetricsMessage::UniquePtr msg) {this->MetricsMessageCallback(*msg);};
     subscription_ = create_subscription<MetricsMessage,
-        std::function<void(MetricsMessage::UniquePtr)>>(kTestTopic, 10 /*history_depth*/, callback);
+        std::function<void(MetricsMessage::UniquePtr)>>(
+      system_metrics_collector::collector_node_constants::kStatisticsTopicName,
+      10 /*history_depth*/, callback);
 
     // tools for calculating expected statistics values
     moving_average_statistics::MovingAverageStatistics stats_calc;
@@ -217,11 +218,6 @@ public:
     options.append_parameter_override(
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       test_constants::kPublishPeriod.count());
-
-    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
-        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=" + kTestTopic};
-    options.arguments(arguments);
 
     test_measure_linux_cpu_ = std::make_shared<TestLinuxCpuMeasurementNode>(
       kTestNodeName, options);

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
 #include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
@@ -136,9 +137,9 @@ public:
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       test_constants::kPublishPeriod.count());
 
-    std::vector<std::string> arguments = { "--ros-args", "--remap", std::string(
-      system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=" + kTestTopic };
+    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
+        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
+      ":=" + kTestTopic};
     options.arguments(arguments);
 
     test_measure_linux_memory_ = std::make_shared<TestLinuxMemoryMeasurementNode>(

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -91,7 +91,7 @@ class TestLinuxMemoryMeasurementNode : public system_metrics_collector::LinuxMem
 {
 public:
   TestLinuxMemoryMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options)
-  : LinuxMemoryMeasurementNode(name, options),
+  : LinuxMemoryMeasurementNode{name, options},
     measurement_index_(0) {}
 
   ~TestLinuxMemoryMeasurementNode() override = default;

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -42,7 +42,6 @@ using system_metrics_collector::ProcessMemInfoLines;
 namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_memory";
-constexpr const char kTestTopic[] = "test_memory_measure_topic";
 constexpr const char kTestMetricName[] = "system_memory_percent_used";
 
 constexpr const std::array<const char *, 10> kSamples = {
@@ -137,11 +136,6 @@ public:
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       test_constants::kPublishPeriod.count());
 
-    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
-        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=" + kTestTopic};
-    options.arguments(arguments);
-
     test_measure_linux_memory_ = std::make_shared<TestLinuxMemoryMeasurementNode>(
       kTestNodeName, options);
 
@@ -176,7 +170,9 @@ public:
   {
     auto callback = [this](MetricsMessage::UniquePtr msg) {this->MetricsMessageCallback(*msg);};
     subscription_ = create_subscription<MetricsMessage,
-        std::function<void(MetricsMessage::UniquePtr)>>(kTestTopic, 10 /*history_depth*/, callback);
+        std::function<void(MetricsMessage::UniquePtr)>>(
+      system_metrics_collector::collector_node_constants::kStatisticsTopicName,
+      10 /*history_depth*/, callback);
 
     // tools for calculating expected statistics values
     moving_average_statistics::MovingAverageStatistics stats_calc;

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -47,7 +47,7 @@ class MockLinuxProcessCpuMeasurementNode : public system_metrics_collector::
 {
 public:
   MockLinuxProcessCpuMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options)
-  : LinuxProcessCpuMeasurementNode(name, options) {}
+  : LinuxProcessCpuMeasurementNode{name, options} {}
 
   /**
    * Exposes the protected member function for testing purposes.

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -40,7 +40,6 @@ using moving_average_statistics::StatisticData;
 namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_process_cpu";
-constexpr const char kTestTopic[] = "test_process_cpu_measure_topic";
 }
 
 class MockLinuxProcessCpuMeasurementNode : public system_metrics_collector::
@@ -92,7 +91,9 @@ public:
   {
     auto callback = [this](MetricsMessage::UniquePtr msg) {this->MetricsMessageCallback(*msg);};
     subscription_ = create_subscription<MetricsMessage,
-        std::function<void(MetricsMessage::UniquePtr)>>(kTestTopic, 10 /*history_depth*/, callback);
+        std::function<void(MetricsMessage::UniquePtr)>>(
+      system_metrics_collector::collector_node_constants::kStatisticsTopicName,
+      10 /*history_depth*/, callback);
 
     // tools for calculating expected statistics values
     moving_average_statistics::MovingAverageStatistics stats_calc;
@@ -231,11 +232,6 @@ public:
     options.append_parameter_override(
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       test_constants::kPublishPeriod.count());
-
-    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
-        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=" + kTestTopic};
-    options.arguments(arguments);
 
     test_node_ = std::make_shared<MockLinuxProcessCpuMeasurementNode>(
       kTestNodeName, options);

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <vector>
 
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
 #include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
@@ -231,9 +232,9 @@ public:
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       test_constants::kPublishPeriod.count());
 
-    std::vector<std::string> arguments = { "--ros-args", "--remap", std::string(
-      system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=" + kTestTopic };
+    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
+        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
+      ":=" + kTestTopic};
     options.arguments(arguments);
 
     test_node_ = std::make_shared<MockLinuxProcessCpuMeasurementNode>(

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #include "../../src/system_metrics_collector/constants.hpp"
 #include "../../src/system_metrics_collector/linux_process_memory_measurement_node.hpp"
@@ -34,7 +35,9 @@ class TestLinuxProcessMemoryMeasurementNode : public system_metrics_collector::
   LinuxProcessMemoryMeasurementNode
 {
 public:
-  TestLinuxProcessMemoryMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options)
+  TestLinuxProcessMemoryMeasurementNode(
+    const std::string & name,
+    const rclcpp::NodeOptions & options)
   : LinuxProcessMemoryMeasurementNode(name, options) {}
 
   std::string GetMetricName() const override
@@ -60,9 +63,9 @@ public:
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       std::chrono::duration_cast<std::chrono::milliseconds>(10s).count());
 
-    std::vector<std::string> arguments = { "--ros-args", "--remap", std::string(
-      system_metrics_collector::collector_node_constants::kStatisticsTopicName) + 
-      ":=test_topic" };
+    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
+        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
+      ":=test_topic"};
     options.arguments(arguments);
 
     test_node_ = std::make_shared<TestLinuxProcessMemoryMeasurementNode>(

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -51,9 +51,9 @@ class LinuxProcessMemoryMeasurementTestFixture : public ::testing::Test
 public:
   void SetUp() override
   {
-    rclcpp::init(0, nullptr);
     using namespace std::chrono_literals;
 
+    rclcpp::init(0, nullptr);
 
     rclcpp::NodeOptions options;
     options.append_parameter_override(
@@ -62,11 +62,6 @@ public:
     options.append_parameter_override(
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       std::chrono::duration_cast<std::chrono::milliseconds>(10s).count());
-
-    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
-        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=test_topic"};
-    options.arguments(arguments);
 
     test_node_ = std::make_shared<TestLinuxProcessMemoryMeasurementNode>(
       "test_periodic_node", options);

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -142,8 +142,17 @@ constexpr std::chrono::milliseconds PeriodicMeasurementTestFixure::kDontPublishD
 
 TEST_F(PeriodicMeasurementTestFixure, Sanity) {
   ASSERT_NE(test_periodic_measurer_, nullptr);
+
   ASSERT_EQ("name=test_periodic_node, measurement_period=50ms,"
-    " publishing_topic=test_topic, publish_period=500ms, started=false,"
+    " publishing_topic=, publish_period=500ms, started=false,"
+    " avg=nan, min=nan, max=nan, std_dev=nan, count=0",
+    test_periodic_measurer_->GetStatusString());
+
+  const bool start_success = test_periodic_measurer_->Start();
+  ASSERT_TRUE(start_success);
+
+  ASSERT_EQ("name=test_periodic_node, measurement_period=50ms,"
+    " publishing_topic=/test_topic, publish_period=500ms, started=true,"
     " avg=nan, min=nan, max=nan, std_dev=nan, count=0",
     test_periodic_measurer_->GetStatusString());
 }
@@ -197,7 +206,7 @@ TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
     system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=");
   ASSERT_THROW(TestPeriodicMeasurementNode("throw",
     rclcpp::NodeOptions().parameter_overrides(parameter_overrides).arguments(arguments)),
-    std::invalid_argument);
+    rclcpp::exceptions::InvalidParameterValueException);
   parameter_overrides.clear();
   arguments.clear();
 
@@ -212,7 +221,7 @@ TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
     system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=");
   ASSERT_THROW(TestPeriodicMeasurementNode("throw",
     rclcpp::NodeOptions().parameter_overrides(parameter_overrides).arguments(arguments)),
-    std::invalid_argument);
+    rclcpp::exceptions::InvalidParameterValueException);
   parameter_overrides.clear();
   arguments.clear();
 
@@ -227,7 +236,7 @@ TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
     system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=" + kTestTopic);
   ASSERT_THROW(TestPeriodicMeasurementNode("throw",
     rclcpp::NodeOptions().parameter_overrides(parameter_overrides).arguments(arguments)),
-    std::invalid_argument);
+    rclcpp::exceptions::InvalidParameterValueException);
   parameter_overrides.clear();
   arguments.clear();
 

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "../../src/moving_average_statistics/types.hpp"
 #include "../../src/system_metrics_collector/collector.hpp"
@@ -102,9 +103,9 @@ public:
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       kDontPublishDuringTest.count());
 
-    std::vector<std::string> arguments = { "--ros-args", "--remap", std::string(
-      system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=" + kTestTopic };
+    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
+        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
+      ":=" + kTestTopic};
     options.arguments(arguments);
 
     test_periodic_measurer_ = std::make_shared<TestPeriodicMeasurementNode>(
@@ -187,11 +188,11 @@ TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
 
   // bad measurement period
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-    std::chrono::milliseconds{-1}.count()));
+      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+      std::chrono::milliseconds{-1}.count()));
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-    kDontPublishDuringTest.count()));
+      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+      kDontPublishDuringTest.count()));
   arguments.push_back(std::string("--ros-args --remap ") +
     system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=");
   ASSERT_THROW(TestPeriodicMeasurementNode("throw",
@@ -202,11 +203,11 @@ TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
 
   // bad measurement period
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-    std::chrono::milliseconds{-1}.count()));
+      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+      std::chrono::milliseconds{-1}.count()));
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-    test_constants::kPublishPeriod.count()));
+      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+      test_constants::kPublishPeriod.count()));
   arguments.push_back(std::string("--ros-args --remap ") +
     system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=");
   ASSERT_THROW(TestPeriodicMeasurementNode("throw",
@@ -217,11 +218,11 @@ TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
 
   // invalid publish period
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-    test_constants::kMeasurePeriod.count()));
+      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+      test_constants::kMeasurePeriod.count()));
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-    std::chrono::milliseconds{-1}.count()));
+      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+      std::chrono::milliseconds{-1}.count()));
   arguments.push_back(std::string("--ros-args --remap ") +
     system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=" + kTestTopic);
   ASSERT_THROW(TestPeriodicMeasurementNode("throw",
@@ -232,11 +233,11 @@ TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
 
   // invalid publish period
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-    std::chrono::milliseconds{2}.count()));
+      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+      std::chrono::milliseconds{2}.count()));
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-    std::chrono::milliseconds{1}.count()));
+      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+      std::chrono::milliseconds{1}.count()));
   arguments.push_back(std::string("--ros-args --remap ") +
     system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=" + kTestTopic);
   ASSERT_THROW(TestPeriodicMeasurementNode("throw",
@@ -247,11 +248,11 @@ TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
 
   // invalid node name
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-    std::chrono::milliseconds{2}.count()));
+      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+      std::chrono::milliseconds{2}.count()));
   parameter_overrides.push_back(rclcpp::Parameter(
-    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-    std::chrono::milliseconds{1}.count()));
+      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+      std::chrono::milliseconds{1}.count()));
   arguments.push_back(std::string("--ros-args --remap ") +
     system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=" + kTestTopic);
   ASSERT_THROW(TestPeriodicMeasurementNode("",

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -45,7 +45,7 @@ class TestPeriodicMeasurementNode : public ::system_metrics_collector::PeriodicM
 {
 public:
   TestPeriodicMeasurementNode(const std::string & name, const rclcpp::NodeOptions & options)
-  : PeriodicMeasurementNode(name, options) {}
+  : PeriodicMeasurementNode{name, options} {}
 
   ~TestPeriodicMeasurementNode() override = default;
 

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -180,20 +180,7 @@ TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
     test_constants::kTestDuration.count() / kDontPublishDuringTest.count(), times_published);
 }
 
-TEST_F(PeriodicMeasurementTestFixure, TestConstructorMeasurementPeriodValidation1) {
-  rclcpp::NodeOptions options;
-  options.append_parameter_override(
-    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-    std::chrono::milliseconds{-1}.count());
-  options.append_parameter_override(
-    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-    kDontPublishDuringTest.count());
-
-  ASSERT_THROW(TestPeriodicMeasurementNode("throw", options),
-    rclcpp::exceptions::InvalidParameterValueException);
-}
-
-TEST_F(PeriodicMeasurementTestFixure, TestConstructorMeasurementPeriodValidation2) {
+TEST_F(PeriodicMeasurementTestFixure, TestConstructorMeasurementPeriodValidation) {
   rclcpp::NodeOptions options;
   options.append_parameter_override(
     system_metrics_collector::collector_node_constants::kCollectPeriodParam,

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -34,7 +34,6 @@
 namespace
 {
 constexpr const char kTestNodeName[] = "test_periodic_node";
-constexpr const char kTestTopic[] = "test_topic";
 constexpr const char kTestMetricname[] = "test_metric_name";
 }  // namespace
 
@@ -181,84 +180,69 @@ TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
     test_constants::kTestDuration.count() / kDontPublishDuringTest.count(), times_published);
 }
 
-TEST_F(PeriodicMeasurementTestFixure, TestConstructorInputValidation) {
-  std::vector<rclcpp::Parameter> parameter_overrides;
-  std::vector<std::string> arguments;
+TEST_F(PeriodicMeasurementTestFixure, TestConstructorMeasurementPeriodValidation1) {
+  rclcpp::NodeOptions options;
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+    std::chrono::milliseconds{-1}.count());
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+    kDontPublishDuringTest.count());
 
-  // bad measurement period
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-      std::chrono::milliseconds{-1}.count()));
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-      kDontPublishDuringTest.count()));
-  arguments.push_back(std::string("--ros-args --remap ") +
-    system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=");
-  ASSERT_THROW(TestPeriodicMeasurementNode("throw",
-    rclcpp::NodeOptions().parameter_overrides(parameter_overrides).arguments(arguments)),
+  ASSERT_THROW(TestPeriodicMeasurementNode("throw", options),
     rclcpp::exceptions::InvalidParameterValueException);
-  parameter_overrides.clear();
-  arguments.clear();
+}
 
-  // bad measurement period
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-      std::chrono::milliseconds{-1}.count()));
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-      test_constants::kPublishPeriod.count()));
-  arguments.push_back(std::string("--ros-args --remap ") +
-    system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=");
-  ASSERT_THROW(TestPeriodicMeasurementNode("throw",
-    rclcpp::NodeOptions().parameter_overrides(parameter_overrides).arguments(arguments)),
+TEST_F(PeriodicMeasurementTestFixure, TestConstructorMeasurementPeriodValidation2) {
+  rclcpp::NodeOptions options;
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+    std::chrono::milliseconds{-1}.count());
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+    test_constants::kPublishPeriod.count());
+
+  ASSERT_THROW(TestPeriodicMeasurementNode("throw", options),
     rclcpp::exceptions::InvalidParameterValueException);
-  parameter_overrides.clear();
-  arguments.clear();
+}
 
-  // invalid publish period
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-      test_constants::kMeasurePeriod.count()));
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-      std::chrono::milliseconds{-1}.count()));
-  arguments.push_back(std::string("--ros-args --remap ") +
-    system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=" + kTestTopic);
-  ASSERT_THROW(TestPeriodicMeasurementNode("throw",
-    rclcpp::NodeOptions().parameter_overrides(parameter_overrides).arguments(arguments)),
+TEST_F(PeriodicMeasurementTestFixure, TestConstructorPublishPeriodValidation1) {
+  rclcpp::NodeOptions options;
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+    test_constants::kMeasurePeriod.count());
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+    std::chrono::milliseconds{-1}.count());
+
+  ASSERT_THROW(TestPeriodicMeasurementNode("throw", options),
     rclcpp::exceptions::InvalidParameterValueException);
-  parameter_overrides.clear();
-  arguments.clear();
+}
 
-  // invalid publish period
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-      std::chrono::milliseconds{2}.count()));
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-      std::chrono::milliseconds{1}.count()));
-  arguments.push_back(std::string("--ros-args --remap ") +
-    system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=" + kTestTopic);
-  ASSERT_THROW(TestPeriodicMeasurementNode("throw",
-    rclcpp::NodeOptions().parameter_overrides(parameter_overrides).arguments(arguments)),
+TEST_F(PeriodicMeasurementTestFixure, TestConstructorPublishPeriodValidation2) {
+  rclcpp::NodeOptions options;
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+    std::chrono::milliseconds{2}.count());
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+    std::chrono::milliseconds{1}.count());
+
+  ASSERT_THROW(TestPeriodicMeasurementNode("throw", options),
     std::invalid_argument);
-  parameter_overrides.clear();
-  arguments.clear();
+}
 
-  // invalid node name
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kCollectPeriodParam,
-      std::chrono::milliseconds{2}.count()));
-  parameter_overrides.push_back(rclcpp::Parameter(
-      system_metrics_collector::collector_node_constants::kPublishPeriodParam,
-      std::chrono::milliseconds{1}.count()));
-  arguments.push_back(std::string("--ros-args --remap ") +
-    system_metrics_collector::collector_node_constants::kStatisticsTopicName + ":=" + kTestTopic);
-  ASSERT_THROW(TestPeriodicMeasurementNode("",
-    rclcpp::NodeOptions().parameter_overrides(parameter_overrides).arguments(arguments)),
+TEST_F(PeriodicMeasurementTestFixure, TestConstructorNodeNameValidation) {
+  rclcpp::NodeOptions options;
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kCollectPeriodParam,
+    test_constants::kMeasurePeriod.count());
+  options.append_parameter_override(
+    system_metrics_collector::collector_node_constants::kPublishPeriodParam,
+    test_constants::kPublishPeriod.count());
+
+  ASSERT_THROW(TestPeriodicMeasurementNode("", options),
     std::invalid_argument);
-  parameter_overrides.clear();
-  arguments.clear();
 }
 
 int main(int argc, char ** argv)

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -103,11 +103,6 @@ public:
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       kDontPublishDuringTest.count());
 
-    std::vector<std::string> arguments = {"--ros-args", "--remap", std::string(
-        system_metrics_collector::collector_node_constants::kStatisticsTopicName) +
-      ":=" + kTestTopic};
-    options.arguments(arguments);
-
     test_periodic_measurer_ = std::make_shared<TestPeriodicMeasurementNode>(
       kTestNodeName, options);
 
@@ -143,16 +138,11 @@ constexpr std::chrono::milliseconds PeriodicMeasurementTestFixure::kDontPublishD
 TEST_F(PeriodicMeasurementTestFixure, Sanity) {
   ASSERT_NE(test_periodic_measurer_, nullptr);
 
-  ASSERT_EQ("name=test_periodic_node, measurement_period=50ms,"
-    " publishing_topic=, publish_period=500ms, started=false,"
-    " avg=nan, min=nan, max=nan, std_dev=nan, count=0",
-    test_periodic_measurer_->GetStatusString());
-
   const bool start_success = test_periodic_measurer_->Start();
   ASSERT_TRUE(start_success);
 
   ASSERT_EQ("name=test_periodic_node, measurement_period=50ms,"
-    " publishing_topic=/test_topic, publish_period=500ms, started=true,"
+    " publishing_topic=/system_metrics, publish_period=500ms, started=true,"
     " avg=nan, min=nan, max=nan, std_dev=nan, count=0",
     test_periodic_measurer_->GetStatusString());
 }


### PR DESCRIPTION
In order to support composeable nodes, the configurations for the node need to come from the `rclcpp::NodeOptions` as opposed to from C++ parameters in code.