### PR TITLE
Add unit test for composeability of nodes

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -28,7 +28,6 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(class_loader REQUIRED)
 find_package(metrics_statistics_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -79,6 +78,7 @@ ament_target_dependencies(linux_memory_collector)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(class_loader REQUIRED)
   find_package(lifecycle_msgs REQUIRED)
 
   ament_lint_auto_find_test_dependencies()

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(class_loader REQUIRED)
 find_package(metrics_statistics_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -121,6 +122,10 @@ if(BUILD_TESTING)
     test/system_metrics_collector/test_periodic_measurement_node.cpp)
   target_link_libraries(test_periodic_measurement_node system_metrics_collector)
   ament_target_dependencies(test_periodic_measurement_node lifecycle_msgs metrics_statistics_msgs rclcpp)
+
+  ament_add_gtest(test_composition
+          test/system_metrics_collector/test_composition.cpp)
+  ament_target_dependencies(test_composition class_loader rclcpp rclcpp_components)
 
   ament_add_gtest(test_utilities
           test/system_metrics_collector/test_utilities.cpp)

--- a/system_metrics_collector/package.xml
+++ b/system_metrics_collector/package.xml
@@ -26,6 +26,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>class_loader</test_depend>
   <test_depend>lifecycle_msgs</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rclcpp_components</test_depend>

--- a/system_metrics_collector/test/system_metrics_collector/test_composition.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_composition.cpp
@@ -1,0 +1,76 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "class_loader/class_loader.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/node_factory.hpp"
+
+#include "test_constants.hpp"
+
+namespace
+{
+constexpr const char kSystemMetricsCollectorLibName[] = "libsystem_metrics_collector.so";
+constexpr const std::array<const char *, 2> kExpectedClassNames = {
+  "system_metrics_collector::LinuxProcessCpuMeasurementNode",
+  "system_metrics_collector::LinuxProcessMemoryMeasurementNode"
+};
+}
+
+bool IsExpectedClassName(const std::string & class_name)
+{
+  for (auto expected_class_name : kExpectedClassNames) {
+    if (class_name.find(expected_class_name) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST(TestComposeableNodes, DlopenTest)
+{
+  rclcpp::init(0, nullptr);
+  rclcpp::executors::SingleThreadedExecutor exec;
+  rclcpp::NodeOptions options;
+
+  auto loader = std::make_unique<class_loader::ClassLoader>(kSystemMetricsCollectorLibName);
+  auto class_names = loader->getAvailableClasses<rclcpp_components::NodeFactory>();
+  ASSERT_EQ(kExpectedClassNames.size(), class_names.size());
+
+  std::vector<rclcpp_components::NodeInstanceWrapper> node_wrappers;
+  for (const auto & class_name : class_names) {
+    ASSERT_TRUE(IsExpectedClassName(class_name));
+    auto node_factory = loader->createInstance<rclcpp_components::NodeFactory>(class_name);
+    auto wrapper = node_factory->create_node_instance(options);
+    exec.add_node(wrapper.get_node_base_interface());
+    node_wrappers.push_back(wrapper);
+  }
+
+  std::promise<bool> empty_promise;
+  std::shared_future<bool> dummy_future = empty_promise.get_future();
+  exec.spin_until_future_complete(dummy_future, test_constants::kTestDuration);
+
+  for (auto & wrapper : node_wrappers) {
+    exec.remove_node(wrapper.get_node_base_interface());
+  }
+  node_wrappers.clear();
+  loader.reset();
+
+  rclcpp::shutdown();
+}

--- a/system_metrics_collector/test/system_metrics_collector/test_composition.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_composition.cpp
@@ -49,13 +49,13 @@ TEST(TestComposeableNodes, DlopenTest)
   rclcpp::NodeOptions options;
 
   const auto loader = std::make_unique<class_loader::ClassLoader>(kSystemMetricsCollectorLibName);
-  auto class_names = loader->getAvailableClasses<rclcpp_components::NodeFactory>();
+  const auto class_names = loader->getAvailableClasses<rclcpp_components::NodeFactory>();
   ASSERT_EQ(kExpectedClassNames.size(), class_names.size());
 
   std::vector<rclcpp_components::NodeInstanceWrapper> node_wrappers;
   for (const auto & class_name : class_names) {
     ASSERT_TRUE(IsExpectedClassName(class_name));
-    auto node_factory = loader->createInstance<rclcpp_components::NodeFactory>(class_name);
+    const auto node_factory = loader->createInstance<rclcpp_components::NodeFactory>(class_name);
     auto wrapper = node_factory->create_node_instance(options);
     exec.add_node(wrapper.get_node_base_interface());
     node_wrappers.push_back(wrapper);

--- a/system_metrics_collector/test/system_metrics_collector/test_composition.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_composition.cpp
@@ -35,12 +35,11 @@ constexpr const std::array<const char *, 2> kExpectedClassNames = {
 
 bool IsExpectedClassName(const std::string & class_name)
 {
-  for (auto expected_class_name : kExpectedClassNames) {
-    if (class_name.find(expected_class_name) != std::string::npos) {
-      return true;
-    }
-  }
-  return false;
+  auto result = std::find_if(kExpectedClassNames.cbegin(), kExpectedClassNames.cend(),
+      [&class_name](const char * expected_class_name) {
+        return class_name.find(expected_class_name) != std::string::npos;
+      });
+  return result != kExpectedClassNames.cend();
 }
 
 TEST(TestComposeableNodes, DlopenTest)
@@ -49,7 +48,7 @@ TEST(TestComposeableNodes, DlopenTest)
   rclcpp::executors::SingleThreadedExecutor exec;
   rclcpp::NodeOptions options;
 
-  auto loader = std::make_unique<class_loader::ClassLoader>(kSystemMetricsCollectorLibName);
+  const auto loader = std::make_unique<class_loader::ClassLoader>(kSystemMetricsCollectorLibName);
   auto class_names = loader->getAvailableClasses<rclcpp_components::NodeFactory>();
   ASSERT_EQ(kExpectedClassNames.size(), class_names.size());
 
@@ -69,8 +68,5 @@ TEST(TestComposeableNodes, DlopenTest)
   for (auto & wrapper : node_wrappers) {
     exec.remove_node(wrapper.get_node_base_interface());
   }
-  node_wrappers.clear();
-  loader.reset();
-
   rclcpp::shutdown();
 }


### PR DESCRIPTION
This adds tests for whether or not `libsystem_metrics_collector.so` contains working composeable nodes. It is based on one of the [composition demos](https://github.com/ros2/demos/blob/master/composition/src/dlopen_composition.cpp).