### PR TITLE
Add unit information to MetricsMessage

### DIFF
--- a/metrics_statistics_msgs/msg/MetricsMessage.msg
+++ b/metrics_statistics_msgs/msg/MetricsMessage.msg
@@ -14,8 +14,11 @@
 # Name metric measurement source, e.g., node, topic, or process name
 string measurement_source_name
 
-# Name of the metric being measured, e.g. cpu_percentage, free_memory_mb, message_age, etc
+# Name of the metric being measured, e.g. cpu_percentage, free_memory_mb, message_age, etc.
 string metrics_source
+
+# Unit of measure of the metric, e.g. percent, mb, seconds, etc.
+string unit
 
 # Measurement window start time
 builtin_interfaces/Time window_start

--- a/system_metrics_collector/README.md
+++ b/system_metrics_collector/README.md
@@ -102,6 +102,7 @@ Using [ros2topic]
 ros2 topic echo /system_metrics
 measurement_source_name: linuxMemoryCollector
 metrics_source: system_memory_percent_used
+unit: percent
 window_start:
   sec: 1579638873
   nanosec: 125927653
@@ -122,6 +123,7 @@ statistics:
 ---
 measurement_source_name: linuxCpuCollector
 metrics_source: system_cpu_percent_used
+unit: percent
 window_start:
   sec: 1579638873
   nanosec: 125928189

--- a/system_metrics_collector/src/system_metrics_collector/constants.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/constants.hpp
@@ -16,6 +16,7 @@
 #define SYSTEM_METRICS_COLLECTOR__CONSTANTS_HPP_
 
 #include <chrono>
+#include <string>
 
 namespace system_metrics_collector
 {
@@ -31,6 +32,7 @@ constexpr const std::chrono::milliseconds kDefaultCollectPeriod{1000};    // 1 s
 constexpr const char kPublishPeriodParam[] = "publish_period";
 constexpr const std::chrono::milliseconds kDefaultPublishPeriod{60000};   // 1 minute
 
+constexpr const char kPercentUnitName[] = "percent";
 
 }  // namespace collector_node_constants
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -18,9 +18,10 @@
 #include <sstream>
 #include <string>
 
-#include "../../src/system_metrics_collector/linux_cpu_measurement_node.hpp"
-#include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
-#include "../../src/system_metrics_collector/utilities.hpp"
+#include "constants.hpp"
+#include "linux_cpu_measurement_node.hpp"
+#include "periodic_measurement_node.hpp"
+#include "utilities.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/logging_macros.h"
@@ -87,7 +88,7 @@ std::string LinuxCpuMeasurementNode::GetMetricName() const
 
 const std::string & LinuxCpuMeasurementNode::GetMetricUnit() const
 {
-  static const std::string unit_name{"percent"};
+  static const std::string unit_name{collector_node_constants::kPercentUnitName};
   return unit_name;
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -85,4 +85,10 @@ std::string LinuxCpuMeasurementNode::GetMetricName() const
   return kMeasurementType;
 }
 
+const std::string & LinuxCpuMeasurementNode::GetMetricUnit() const
+{
+  static const std::string unit_name{"percent"};
+  return unit_name;
+}
+
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -73,10 +73,18 @@ private:
   virtual system_metrics_collector::ProcCpuData MakeSingleMeasurement();
 
   /**
-   * Return the name to use for this metric
+   * Returns the name to use for this metric
+   *
    * @return a string of the name for this measured metric
    */
   std::string GetMetricName() const override;
+
+  /**
+   * Returns the name of the measurement unit of this metric
+   *
+   * @return a string of the name of the measurement unit of this metric
+   */
+  const std::string & GetMetricUnit() const override;
 
   /**
    * The cached measurement used in order to perform the CPU active

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -58,5 +58,10 @@ std::string LinuxMemoryMeasurementNode::GetMetricName() const
   return kMeasurementType;
 }
 
+const std::string & LinuxMemoryMeasurementNode::GetMetricUnit() const
+{
+  static const std::string unit_name{"percent"};
+  return unit_name;
+}
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -18,9 +18,10 @@
 #include <streambuf>
 #include <string>
 
-#include "../../src/system_metrics_collector/linux_memory_measurement_node.hpp"
-#include "../../src/system_metrics_collector/periodic_measurement_node.hpp"
-#include "../../src/system_metrics_collector/utilities.hpp"
+#include "constants.hpp"
+#include "linux_memory_measurement_node.hpp"
+#include "periodic_measurement_node.hpp"
+#include "utilities.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/logging_macros.h"
@@ -60,7 +61,7 @@ std::string LinuxMemoryMeasurementNode::GetMetricName() const
 
 const std::string & LinuxMemoryMeasurementNode::GetMetricUnit() const
 {
-  static const std::string unit_name{"percent"};
+  static const std::string unit_name{collector_node_constants::kPercentUnitName};
   return unit_name;
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -56,10 +56,18 @@ protected:
   double PeriodicMeasurement() override;
 
   /**
-   * Return the name to use for this metric
+   * Returns the name to use for this metric
+   *
    * @return a string of the name for this measured metric
    */
   std::string GetMetricName() const override;
+
+  /**
+   * Returns the name of the measurement unit of this metric
+   *
+   * @return a string of the name of the measurement unit of this metric
+   */
+  const std::string & GetMetricUnit() const override;
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -27,6 +27,8 @@
 #include "rclcpp_components/register_node_macro.hpp"
 #include "rcutils/logging_macros.h"
 
+#include "constants.hpp"
+
 namespace
 {
 
@@ -85,7 +87,7 @@ std::string LinuxProcessCpuMeasurementNode::GetMetricName() const
 
 const std::string & LinuxProcessCpuMeasurementNode::GetMetricUnit() const
 {
-  static const std::string unit_name{"percent"};
+  static const std::string unit_name{collector_node_constants::kPercentUnitName};
   return unit_name;
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -83,6 +83,12 @@ std::string LinuxProcessCpuMeasurementNode::GetMetricName() const
   return metric_name_;
 }
 
+const std::string & LinuxProcessCpuMeasurementNode::GetMetricUnit() const
+{
+  static const std::string unit_name{"percent"};
+  return unit_name;
+}
+
 }   // namespace system_metrics_collector
 
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -89,6 +89,13 @@ protected:
    */
   std::string GetMetricName() const override;
 
+  /**
+   * Returns the name of the measurement unit of this metric
+   *
+   * @return a string of the name of the measurement unit of this metric
+   */
+  const std::string & GetMetricUnit() const override;
+
 private:
   /**
    * Performs a single measurement of CPU data by using clock_gettime().

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -26,6 +26,8 @@
 #include "rclcpp_components/register_node_macro.hpp"
 #include "rcutils/logging_macros.h"
 
+#include "constants.hpp"
+
 namespace
 {
 
@@ -92,7 +94,7 @@ std::string LinuxProcessMemoryMeasurementNode::GetMetricName() const
 
 const std::string & LinuxProcessMemoryMeasurementNode::GetMetricUnit() const
 {
-  static const std::string unit_name{"percent"};
+  static const std::string unit_name{collector_node_constants::kPercentUnitName};
   return unit_name;
 }
 

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -90,6 +90,12 @@ std::string LinuxProcessMemoryMeasurementNode::GetMetricName() const
   return pid_ + kMetricName;
 }
 
+const std::string & LinuxProcessMemoryMeasurementNode::GetMetricUnit() const
+{
+  static const std::string unit_name{"percent"};
+  return unit_name;
+}
+
 uint64_t GetProcessUsedMemory(const std::string & statm_process_file_contents)
 {
   std::istringstream ss{statm_process_file_contents};

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -72,10 +72,18 @@ public:
 
 protected:
   /**
-   * Return the name to use for this metric
+   * Returns the name to use for this metric
+   *
    * @return a string of the name for this measured metric
    */
   std::string GetMetricName() const override;
+
+  /**
+   * Returns the name of the measurement unit of this metric
+   *
+   * @return a string of the name of the measurement unit of this metric
+   */
+  const std::string & GetMetricUnit() const override;
 
 private:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.cpp
@@ -29,6 +29,7 @@ namespace system_metrics_collector
 MetricsMessage MetricsMessagePublisher::GenerateStatisticMessage(
   const std::string & node_name,
   const std::string & metric_name,
+  const std::string & unit,
   const builtin_interfaces::msg::Time window_start,
   const builtin_interfaces::msg::Time window_stop,
   const moving_average_statistics::StatisticData & data)
@@ -37,6 +38,7 @@ MetricsMessage MetricsMessagePublisher::GenerateStatisticMessage(
 
   msg.measurement_source_name = node_name;
   msg.metrics_source = metric_name;
+  msg.unit = unit;
   msg.window_start = window_start;
   msg.window_stop = window_stop;
 

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -37,6 +37,7 @@ public:
    *
    * @param node_name the name of the node that the data originates from
    * @param metric_name the name of the metric ("cpu_usage", "memory_usage", etc.)
+   * @param unit name of the unit ("percentage", "mb", etc.)
    * @param window_start measurement window start time
    * @param window_stop measurement window end time
    * @param data statistics derived from the measurements made in the window
@@ -45,6 +46,7 @@ public:
   static metrics_statistics_msgs::msg::MetricsMessage GenerateStatisticMessage(
     const std::string & node_name,
     const std::string & metric_name,
+    const std::string & unit,
     const builtin_interfaces::msg::Time window_start,
     const builtin_interfaces::msg::Time window_stop,
     const moving_average_statistics::StatisticData & data
@@ -57,10 +59,18 @@ public:
   virtual void PublishStatisticMessage() = 0;
 
   /**
-   * Return the name to use for this metric
+   * Returns the name to use for this metric
+   *
    * @return a string of the name for this measured metric
    */
   virtual std::string GetMetricName() const = 0;
+
+  /**
+   * Returns the name of the measurement unit of this metric
+   *
+   * @return a string of the name of the measurement unit of this metric
+   */
+  virtual const std::string & GetMetricUnit() const = 0;
 };
 }  // namespace system_metrics_collector
 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -175,11 +175,13 @@ void PeriodicMeasurementNode::PublishStatisticMessage()
   assert(publisher_ != nullptr);
   assert(publisher_->is_activated());
 
-  const auto msg = GenerateStatisticMessage(get_name(),
-      GetMetricName(),
-      window_start_,
-      now(),
-      GetStatisticsResults());
+  const auto msg = GenerateStatisticMessage(
+    get_name(),
+    GetMetricName(),
+    GetMetricUnit(),
+    window_start_,
+    now(),
+    GetStatisticsResults());
   publisher_->publish(msg);
 }
 

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -50,6 +50,7 @@ namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_cpu";
 constexpr const char kTestMetricName[] = "system_cpu_percent_used";
+constexpr const char kTestMetricUnit[] = "percent";
 }  // namespace
 
 /**
@@ -191,6 +192,7 @@ private:
     // check source names
     EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
     EXPECT_EQ(kTestMetricName, msg.metrics_source);
+    EXPECT_EQ(kTestMetricUnit, msg.unit);
 
     // check measurements
     const ExpectedStatistics & expected_stat = expected_stats_[times_received_];

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -50,7 +50,6 @@ namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_cpu";
 constexpr const char kTestMetricName[] = "system_cpu_percent_used";
-constexpr const char kTestMetricUnit[] = "percent";
 }  // namespace
 
 /**
@@ -192,7 +191,7 @@ private:
     // check source names
     EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
     EXPECT_EQ(kTestMetricName, msg.metrics_source);
-    EXPECT_EQ(kTestMetricUnit, msg.unit);
+    EXPECT_EQ(system_metrics_collector::collector_node_constants::kPercentUnitName, msg.unit);
 
     // check measurements
     const ExpectedStatistics & expected_stat = expected_stats_[times_received_];

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -46,7 +46,6 @@ namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_memory";
 constexpr const char kTestMetricName[] = "system_memory_percent_used";
-constexpr const char kTestMetricUnit[] = "percent";
 
 constexpr const std::array<const char *, 10> kSamples = {
   test_constants::kFullSample,
@@ -262,7 +261,7 @@ private:
     // check source names
     EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
     EXPECT_EQ(kTestMetricName, msg.metrics_source);
-    EXPECT_EQ(kTestMetricUnit, msg.unit);
+    EXPECT_EQ(system_metrics_collector::collector_node_constants::kPercentUnitName, msg.unit);
 
     // check measurements
     const ExpectedStatistics & expected_stat = expected_stats_[times_received_];

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -46,6 +46,7 @@ namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_memory";
 constexpr const char kTestMetricName[] = "system_memory_percent_used";
+constexpr const char kTestMetricUnit[] = "percent";
 
 constexpr const std::array<const char *, 10> kSamples = {
   test_constants::kFullSample,
@@ -261,6 +262,7 @@ private:
     // check source names
     EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
     EXPECT_EQ(kTestMetricName, msg.metrics_source);
+    EXPECT_EQ(kTestMetricUnit, msg.unit);
 
     // check measurements
     const ExpectedStatistics & expected_stat = expected_stats_[times_received_];

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -43,7 +43,6 @@ using moving_average_statistics::StatisticData;
 namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_process_cpu";
-constexpr const char kTestMetricUnit[] = "percent";
 }
 
 class MockLinuxProcessCpuMeasurementNode : public system_metrics_collector::
@@ -197,7 +196,7 @@ private:
     // check source names
     EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
     EXPECT_EQ(expected_metric_name_, msg.metrics_source);
-    EXPECT_EQ(kTestMetricUnit, msg.unit);
+    EXPECT_EQ(system_metrics_collector::collector_node_constants::kPercentUnitName, msg.unit);
 
     // check measurements
     const ExpectedStatistics & expected_stat = expected_stats_[times_received_];

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -43,6 +43,7 @@ using moving_average_statistics::StatisticData;
 namespace
 {
 constexpr const char kTestNodeName[] = "test_measure_linux_process_cpu";
+constexpr const char kTestMetricUnit[] = "percent";
 }
 
 class MockLinuxProcessCpuMeasurementNode : public system_metrics_collector::
@@ -196,6 +197,7 @@ private:
     // check source names
     EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
     EXPECT_EQ(expected_metric_name_, msg.metrics_source);
+    EXPECT_EQ(kTestMetricUnit, msg.unit);
 
     // check measurements
     const ExpectedStatistics & expected_stat = expected_stats_[times_received_];

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -33,8 +33,6 @@ using lifecycle_msgs::msg::State;
 namespace
 {
 constexpr const char kTestNodeName[] = "test_periodic_node";
-constexpr const char kTestMetricUnit[] = "percent";
-
 constexpr const char kTestStatmLine[] = "2084389 308110 7390 1 0 366785 0\n";
 }
 
@@ -121,5 +119,6 @@ TEST_F(LinuxProcessMemoryMeasurementTestFixture, TestGetMetricName) {
 
 TEST_F(LinuxProcessMemoryMeasurementTestFixture, TestGetMetricUnit) {
   const auto pid = system_metrics_collector::GetPid();
-  ASSERT_EQ(kTestMetricUnit, test_node_->GetMetricUnit());
+  ASSERT_EQ(system_metrics_collector::collector_node_constants::kPercentUnitName,
+    test_node_->GetMetricUnit());
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -32,6 +32,9 @@ using lifecycle_msgs::msg::State;
 
 namespace
 {
+constexpr const char kTestNodeName[] = "test_periodic_node";
+constexpr const char kTestMetricUnit[] = "percent";
+
 constexpr const char kTestStatmLine[] = "2084389 308110 7390 1 0 366785 0\n";
 }
 
@@ -47,6 +50,11 @@ public:
   std::string GetMetricName() const override
   {
     return LinuxProcessMemoryMeasurementNode::GetMetricName();
+  }
+
+  const std::string & GetMetricUnit() const override
+  {
+    return LinuxProcessMemoryMeasurementNode::GetMetricUnit();
   }
 };
 
@@ -68,7 +76,7 @@ public:
       std::chrono::duration_cast<std::chrono::milliseconds>(10s).count());
 
     test_node_ = std::make_shared<TestLinuxProcessMemoryMeasurementNode>(
-      "test_periodic_node", options);
+      kTestNodeName, options);
 
     ASSERT_FALSE(test_node_->IsStarted());
     ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node_->get_current_state().id());
@@ -108,6 +116,10 @@ TEST(TestLinuxProcessMemoryMeasurement, TestGetProcessUsedMemory) {
 
 TEST_F(LinuxProcessMemoryMeasurementTestFixture, TestGetMetricName) {
   const auto pid = system_metrics_collector::GetPid();
-
   ASSERT_EQ(std::to_string(pid) + "_memory_percent_used", test_node_->GetMetricName());
+}
+
+TEST_F(LinuxProcessMemoryMeasurementTestFixture, TestGetMetricUnit) {
+  const auto pid = system_metrics_collector::GetPid();
+  ASSERT_EQ(kTestMetricUnit, test_node_->GetMetricUnit());
 }

--- a/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
@@ -33,6 +33,7 @@ namespace
 {
 constexpr const char kTestNodeName[] = "test_publisher";
 constexpr const char kTestMeasurementType[] = "test_measurement";
+constexpr const char kTestMeasurementUnit[] = "test_unit";
 }  // namespace
 
 TEST(MetricsMessagePublisherTest, TestGenerateMessage) {
@@ -51,10 +52,11 @@ TEST(MetricsMessagePublisherTest, TestGenerateMessage) {
   data.sample_count = dist(gen);
 
   MetricsMessage msg = MetricsMessagePublisher::GenerateStatisticMessage(
-    kTestNodeName, kTestMeasurementType, time1, time2, data);
+    kTestNodeName, kTestMeasurementType, kTestMeasurementUnit, time1, time2, data);
 
   EXPECT_EQ(kTestNodeName, msg.measurement_source_name);
   EXPECT_EQ(kTestMeasurementType, msg.metrics_source);
+  EXPECT_EQ(kTestMeasurementUnit, msg.unit);
   EXPECT_EQ(time1, msg.window_start);
   EXPECT_EQ(time2, msg.window_stop);
 

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -38,7 +38,8 @@ using lifecycle_msgs::msg::State;
 namespace
 {
 constexpr const char kTestNodeName[] = "test_periodic_node";
-constexpr const char kTestMetricname[] = "test_metric_name";
+constexpr const char kTestMetricName[] = "test_metric_name";
+constexpr const char kTestMetricUnit[] = "test_unit";
 }  // namespace
 
 /**
@@ -91,7 +92,13 @@ private:
 
   std::string GetMetricName() const override
   {
-    return kTestMetricname;
+    return kTestMetricName;
+  }
+
+  const std::string & GetMetricUnit() const override
+  {
+    static const std::string unit_name{kTestMetricUnit};
+    return unit_name;
   }
 
   std::atomic<int> times_measured_{0};


### PR DESCRIPTION
Add a field containing unit information to `MetricsMessage`. This makes `MetricsMessage` more compatible with Cloudwatch Metrics' `MetricDatum`, but it's meaningful information to have anyways in its own right.