### PR TITLE
Use Docker CI image to run the lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,15 +4,17 @@ on:
 
 jobs:
   ament_lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
         linter: [copyright, cppcheck, cpplint, flake8, pep257, uncrustify, xmllint]
     steps:
-      - uses: actions/checkout@v1
-      - uses: ros-tooling/setup-ros@0.0.20
-      - uses: ros-tooling/action-ros2-lint@0.0.6
+      - run: sudo chown -R rosbuild:rosbuild "$HOME" .
+      - uses: actions/checkout@v2
+      - uses: ros-tooling/action-ros-lint@0.0.6
         with:
           linter: ${{ matrix.linter }}
           package-name: system_metrics_collector


### PR DESCRIPTION
Using `setup-ros`, linting the repository takes 2 to 3 minutes, relying on the Docker image, this takes now about 50 seconds.