### PR TITLE
Add message age collector class

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(message_filters REQUIRED)
 find_package(metrics_statistics_msgs REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -35,6 +36,8 @@ find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 
 include_directories(src)
 
@@ -54,6 +57,7 @@ add_library(system_metrics_collector SHARED
   src/system_metrics_collector/utilities.cpp
 )
 ament_target_dependencies(system_metrics_collector
+        message_filters
         metrics_statistics_msgs
         rcl
         rclcpp
@@ -141,6 +145,11 @@ if(BUILD_TESTING)
   target_link_libraries(test_received_message_period system_metrics_collector)
   ament_target_dependencies(test_received_message_period rcl rclcpp)
 
+  ament_add_gtest(test_received_message_age
+          test/topic_statistics_collector/test_received_message_age.cpp)
+  target_link_libraries(test_received_message_age system_metrics_collector)
+  ament_target_dependencies(test_received_message_age rcl rclcpp message_filters std_msgs sensor_msgs)
+
   install(TARGETS
     test_moving_average_statistics
     DESTINATION
@@ -155,6 +164,10 @@ if(BUILD_TESTING)
     lib/${PROJECT_NAME})
   install(TARGETS
     test_received_message_period
+    DESTINATION
+    lib/${PROJECT_NAME})
+  install(TARGETS
+    test_received_message_age
     DESTINATION
     lib/${PROJECT_NAME})
 endif()

--- a/system_metrics_collector/package.xml
+++ b/system_metrics_collector/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>message_filters</depend>
   <depend>metrics_statistics_msgs</depend>
   <depend>rcl</depend>
   <depend>rclcpp</depend>
@@ -16,6 +17,8 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>rcpputils</depend>
   <depend>rcutils</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
 
   <!--Required for example launch file-->
   <exec_depend>demo_nodes_cpp</exec_depend>
@@ -25,7 +28,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>class_loader</test_depend>
   <test_depend>lifecycle_msgs</test_depend>
-  
+
   <!--Required for e2e test file-->
   <test_depend>python3-retrying</test_depend>
   <test_depend>rclpy</test_depend>

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
@@ -66,8 +66,7 @@ public:
       if (timestamp_from_header.get_clock_type() == now.get_clock_type()) {
         const std::chrono::nanoseconds age_nanos{
           now.nanoseconds() - timestamp_from_header.nanoseconds()};
-        const std::chrono::milliseconds age_millis{
-          std::chrono::duration_cast<std::chrono::milliseconds>(age_nanos)};
+        const auto age_millis = std::chrono::duration_cast<std::chrono::milliseconds>(age_nanos);
 
         system_metrics_collector::Collector::AcceptData(static_cast<double>(age_millis.count()));
       } else {

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <string>
+#include <sstream>
 
 #include "topic_statistics_collector.hpp"
 
@@ -70,9 +71,13 @@ public:
 
         system_metrics_collector::Collector::AcceptData(static_cast<double>(age_millis.count()));
       } else {
-        RCUTILS_LOG_WARN_NAMED(
-          "topic_statistics_collector",
-          "Message header and current clock have different time sources, no metric reported");
+        std::stringstream warn_msg;
+        warn_msg <<
+          "Message header and current clock have different time sources, " <<
+          "cannot measure message age" <<
+          "\nmessage header clock type: " << timestamp_from_header.get_clock_type() <<
+          "\ncollector clock type: " << clock_.get_clock_type();
+        RCUTILS_LOG_WARN_NAMED("topic_statistics_collector", "%s", warn_msg.str().c_str());
       }
     }
   }

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
@@ -1,0 +1,97 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOPIC_STATISTICS_COLLECTOR__RECEIVED_MESSAGE_AGE_HPP_
+#define TOPIC_STATISTICS_COLLECTOR__RECEIVED_MESSAGE_AGE_HPP_
+
+#include <chrono>
+#include <string>
+
+#include "topic_statistics_collector.hpp"
+
+#include "message_filters/message_traits.h"
+#include "rcl/time.h"
+#include "rclcpp/clock.hpp"
+
+
+namespace topic_statistics_collector
+{
+/**
+ * Class used to measure the received messsage, tparam T, age from a ROS2 subscriber.
+ *
+ * @tparam T the message type to receive from the subscriber / listener
+*/
+template<typename T>
+class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
+{
+public:
+  explicit ReceivedMessageAgeCollector(
+    const rclcpp::Clock & clock = rclcpp::Clock{RCL_STEADY_TIME})
+  : clock_{clock}
+  {}
+
+  virtual ~ReceivedMessageAgeCollector() = default;
+
+  /**
+  * Handle a new incoming message. Calculate message age if a valid Header is present.
+  */
+  void OnMessageReceived(const T & received_message) override
+  {
+    const rclcpp::Time timestamp_from_header = message_filters::message_traits::TimeStamp<T>::value(
+      received_message);
+
+    if (timestamp_from_header.nanoseconds()) {
+      const auto now = GetCurrentTime();
+
+      const std::chrono::nanoseconds age_nanos{
+        now.nanoseconds() - timestamp_from_header.nanoseconds()};
+      const std::chrono::milliseconds age_millis{
+        std::chrono::duration_cast<std::chrono::milliseconds>(age_nanos)};
+
+      system_metrics_collector::Collector::AcceptData(static_cast<double>(age_millis.count()));
+    }
+  }
+
+  /**
+   * Return the current time using high_resolution_clock.
+   * Defined as virtual for testing and if another clock implementation is desired.
+   *
+   * @return the current time provided by the clock given at construction time
+   */
+  virtual rclcpp::Time GetCurrentTime()
+  {
+    return clock_.now();
+  }
+
+protected:
+  bool SetupStart() override
+  {
+    return true;
+  }
+
+  bool SetupStop() override
+  {
+    return true;
+  }
+
+private:
+  /**
+   * The clock to use in order to determine the age of incoming messages.
+   */
+  rclcpp::Clock clock_;
+};
+
+}  // namespace topic_statistics_collector
+
+#endif  // TOPIC_STATISTICS_COLLECTOR__RECEIVED_MESSAGE_AGE_HPP_

--- a/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
@@ -31,7 +31,7 @@ constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
 constexpr const double kExpectedAverageMilliseconds{2000.0};
 constexpr const double kExpectedMinMilliseconds{1000.0};
 constexpr const double kExpectedMaxMilliseconds{3000.0};
-constexpr const double kExpectedStandardDeviation{816};
+constexpr const double kExpectedStandardDeviation{816.49658092772597};
 const rclcpp::Time kDefaultSystemTime{0, 0, RCL_SYSTEM_TIME};
 constexpr const int kDefaultTimesToTest{10};
 }  // namespace
@@ -70,15 +70,15 @@ public:
 
 sensor_msgs::msg::Imu GetImuMessageWithHeader(const int64_t timestamp)
 {
-  auto message = sensor_msgs::msg::Imu();
-  message.header = std_msgs::msg::Header();
-  message.header.stamp = rclcpp::Time(timestamp);
+  auto message = sensor_msgs::msg::Imu{};
+  message.header = std_msgs::msg::Header{};
+  message.header.stamp = rclcpp::Time{timestamp};
   return message;
 }
 
 std_msgs::msg::String GetStringMessageWithoutHeader()
 {
-  auto message = std_msgs::msg::String();
+  auto message = std_msgs::msg::String{};
   message.data = "Any message with no header";
   return message;
 }
@@ -114,7 +114,7 @@ TEST(ReceivedMessageAgeTest, TestMeasurementOnlyMadeForInitializedHeaderValue) {
   imu_msg_collector{clock};
 
   // Don't initialize `header.stamp`
-  const auto imu_msg_uninitialized_header = sensor_msgs::msg::Imu();
+  const auto imu_msg_uninitialized_header = sensor_msgs::msg::Imu{};
   imu_msg_collector.OnMessageReceived(imu_msg_uninitialized_header);
   auto stats = imu_msg_collector.GetStatisticsResults();
   EXPECT_EQ(0, stats.sample_count) << "Expect 0 samples to be collected";
@@ -175,5 +175,5 @@ TEST(ReceivedMessageAgeTest, TestAgeMeasurement) {
   EXPECT_EQ(kExpectedAverageMilliseconds, stats.average);
   EXPECT_EQ(kExpectedMinMilliseconds, stats.min);
   EXPECT_EQ(kExpectedMaxMilliseconds, stats.max);
-  EXPECT_EQ(kExpectedStandardDeviation, std::floor(stats.standard_deviation));
+  EXPECT_DOUBLE_EQ(kExpectedStandardDeviation, stats.standard_deviation);
 }

--- a/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
@@ -1,0 +1,157 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+
+#include "topic_statistics_collector/received_message_age.hpp"
+
+#include "rclcpp/clock.hpp"
+#include "rcl/time.h"
+#include "sensor_msgs/msg/imu.hpp"
+#include "std_msgs/msg/string.hpp"
+
+
+namespace
+{
+constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
+constexpr const double kExpectedAverageMilliseconds{2000.0};
+constexpr const double kExpectedMinMilliseconds{1000.0};
+constexpr const double kExpectedMaxMilliseconds{3000.0};
+constexpr const double kExpectedStandardDeviation{816};
+const rclcpp::Time kDefaultSystemTime{0, 0, RCL_SYSTEM_TIME};
+constexpr const int kDefaultTimesToTest{10};
+}  // namespace
+
+class TestReceivedMessageAgeCollector
+  : public topic_statistics_collector::ReceivedMessageAgeCollector<
+    sensor_msgs::msg::Imu>
+{
+public:
+  TestReceivedMessageAgeCollector()
+  {
+    fake_now_ = ReceivedMessageAgeCollector::GetCurrentTime().nanoseconds();
+  }
+  virtual ~TestReceivedMessageAgeCollector() = default;
+
+  /**
+   * Overridden in order to mock the clock for measurement testing.
+   * @return a fixed time point
+   */
+  rclcpp::Time GetCurrentTime() override
+  {
+    return rclcpp::Time{fake_now_, RCL_SYSTEM_TIME};
+  }
+
+  /**
+   * Advance time by a specified duration, in seconds.
+   * @param seconds duration which to advance time
+   */
+  void AdvanceTime(std::chrono::nanoseconds nanos)
+  {
+    fake_now_ += nanos.count();
+  }
+
+  int64_t fake_now_;
+};
+
+sensor_msgs::msg::Imu GetImuMessageWithHeader(const int64_t timestamp)
+{
+  auto message = sensor_msgs::msg::Imu();
+  message.header = std_msgs::msg::Header();
+  message.header.stamp = rclcpp::Time(timestamp);
+  return message;
+}
+
+std_msgs::msg::String GetStringMessageWithoutHeader()
+{
+  auto message = std_msgs::msg::String();
+  message.data = "Any message with no header";
+  return message;
+}
+
+TEST(ReceivedMessageAgeTest, TestOnlyMessagesWithHeaderGetSampled) {
+  rclcpp::Clock clock{RCL_SYSTEM_TIME};
+  topic_statistics_collector::ReceivedMessageAgeCollector<std_msgs::msg::String>
+  string_msg_collector{clock};
+
+  const auto string_msg = GetStringMessageWithoutHeader();
+  moving_average_statistics::StatisticData stats;
+
+  for (int i = 0; i < kDefaultTimesToTest; ++i) {
+    string_msg_collector.OnMessageReceived(string_msg);
+    stats = string_msg_collector.GetStatisticsResults();
+    EXPECT_EQ(0, stats.sample_count) << "Expect 0 samples to be collected";
+  }
+
+  topic_statistics_collector::ReceivedMessageAgeCollector<sensor_msgs::msg::Imu>
+  imu_msg_collector{clock};
+  const auto imu_msg = GetImuMessageWithHeader(clock.now().nanoseconds());
+
+  for (int i = 0; i < kDefaultTimesToTest; ++i) {
+    imu_msg_collector.OnMessageReceived(imu_msg);
+    stats = imu_msg_collector.GetStatisticsResults();
+    EXPECT_EQ(i + 1, stats.sample_count) << "Expect " << i + 1 << " samples to be collected";
+  }
+}
+
+TEST(ReceivedMessageAgeTest, TestMeasurementOnlyMadeForPositiveHeaderValue) {
+  rclcpp::Clock clock{RCL_SYSTEM_TIME};
+  topic_statistics_collector::ReceivedMessageAgeCollector<sensor_msgs::msg::Imu>
+  imu_msg_collector{clock};
+
+  const auto imu_msg_zero_header = GetImuMessageWithHeader(0);
+  imu_msg_collector.OnMessageReceived(imu_msg_zero_header);
+  auto stats = imu_msg_collector.GetStatisticsResults();
+  EXPECT_EQ(0, stats.sample_count) << "Expect 0 samples to be collected";
+
+  const auto imu_msg_positive_header = GetImuMessageWithHeader(1);
+  imu_msg_collector.OnMessageReceived(imu_msg_positive_header);
+  stats = imu_msg_collector.GetStatisticsResults();
+  EXPECT_EQ(1, stats.sample_count) << "Expect 1 sample to be collected";
+}
+
+TEST(ReceivedMessageAgeTest, TestAgeMeasurement) {
+  TestReceivedMessageAgeCollector test_collector{};
+  EXPECT_NE(kDefaultSystemTime, test_collector.GetCurrentTime());
+
+  EXPECT_FALSE(test_collector.IsStarted()) << "Expect to be not started after constructed";
+
+  EXPECT_TRUE(test_collector.Start()) << "Expect Start() to be successful";
+  EXPECT_TRUE(test_collector.IsStarted()) << "Expect to be started";
+
+  const auto test_message = GetImuMessageWithHeader(test_collector.fake_now_);
+
+  test_collector.AdvanceTime(kDefaultDurationSeconds);
+  test_collector.OnMessageReceived(test_message);
+  auto stats = test_collector.GetStatisticsResults();
+  EXPECT_EQ(1, stats.sample_count);
+
+  test_collector.AdvanceTime(kDefaultDurationSeconds);
+  test_collector.OnMessageReceived(test_message);
+  stats = test_collector.GetStatisticsResults();
+  EXPECT_EQ(2, stats.sample_count);
+
+  test_collector.AdvanceTime(kDefaultDurationSeconds);
+  test_collector.OnMessageReceived(test_message);
+  stats = test_collector.GetStatisticsResults();
+  EXPECT_EQ(3, stats.sample_count);
+
+  EXPECT_EQ(kExpectedAverageMilliseconds, stats.average);
+  EXPECT_EQ(kExpectedMinMilliseconds, stats.min);
+  EXPECT_EQ(kExpectedMaxMilliseconds, stats.max);
+  EXPECT_EQ(kExpectedStandardDeviation, std::floor(stats.standard_deviation));
+}


### PR DESCRIPTION
New class to calculate `message_age` metric, analogous to existing `received_message_period` class.

Related to https://github.com/ros-tooling/aws-roadmap/issues/186

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>