### PR TITLE
Add statistic name and unit interfaces

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/collector.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.hpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <string>
 
+#include "metric_details_interface.hpp"
 #include "moving_average_statistics/moving_average.hpp"
 #include "moving_average_statistics/types.hpp"
 
@@ -29,7 +30,7 @@ namespace system_metrics_collector
 /**
  * Simple class in order to collect observed data and generate statistics for the given observations.
  */
-class Collector
+class Collector : virtual public MetricDetailsInterface
 {
 public:
   Collector() = default;
@@ -90,6 +91,20 @@ public:
    * @return true if stopped, false if an error occurred
    */
   virtual bool Stop();
+
+  /**
+   * Return the name of the metric collected.
+   *
+   * @return string reporesenting name of the collected metric
+   */
+  std::string GetMetricName() const override = 0;
+
+  /**
+   * Return the measurement unit of the metric collected.
+   *
+   * @return string representing unit of the metric collected
+   */
+  std::string GetMetricUnit() const override = 0;
 
 private:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/collector.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.hpp
@@ -30,7 +30,7 @@ namespace system_metrics_collector
 /**
  * Simple class in order to collect observed data and generate statistics for the given observations.
  */
-class Collector : virtual public MetricDetailsInterface
+class Collector : public MetricDetailsInterface
 {
 public:
   Collector() = default;

--- a/system_metrics_collector/src/system_metrics_collector/collector.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/collector.hpp
@@ -92,20 +92,6 @@ public:
    */
   virtual bool Stop();
 
-  /**
-   * Return the name of the metric collected.
-   *
-   * @return string reporesenting name of the collected metric
-   */
-  std::string GetMetricName() const override = 0;
-
-  /**
-   * Return the measurement unit of the metric collected.
-   *
-   * @return string representing unit of the metric collected
-   */
-  std::string GetMetricUnit() const override = 0;
-
 private:
   /**
    * Override in order to perform necessary starting steps.

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.cpp
@@ -86,10 +86,9 @@ std::string LinuxCpuMeasurementNode::GetMetricName() const
   return kMeasurementType;
 }
 
-const std::string & LinuxCpuMeasurementNode::GetMetricUnit() const
+std::string LinuxCpuMeasurementNode::GetMetricUnit() const
 {
-  static const std::string unit_name{collector_node_constants::kPercentUnitName};
-  return unit_name;
+  return collector_node_constants::kPercentUnitName;
 }
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_cpu_measurement_node.hpp
@@ -84,7 +84,7 @@ private:
    *
    * @return a string of the name of the measurement unit of this metric
    */
-  const std::string & GetMetricUnit() const override;
+  std::string GetMetricUnit() const override;
 
   /**
    * The cached measurement used in order to perform the CPU active

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.cpp
@@ -59,10 +59,9 @@ std::string LinuxMemoryMeasurementNode::GetMetricName() const
   return kMeasurementType;
 }
 
-const std::string & LinuxMemoryMeasurementNode::GetMetricUnit() const
+std::string LinuxMemoryMeasurementNode::GetMetricUnit() const
 {
-  static const std::string unit_name{collector_node_constants::kPercentUnitName};
-  return unit_name;
+  return collector_node_constants::kPercentUnitName;
 }
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_memory_measurement_node.hpp
@@ -67,7 +67,7 @@ protected:
    *
    * @return a string of the name of the measurement unit of this metric
    */
-  const std::string & GetMetricUnit() const override;
+  std::string GetMetricUnit() const override;
 };
 
 }  // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.cpp
@@ -85,10 +85,9 @@ std::string LinuxProcessCpuMeasurementNode::GetMetricName() const
   return metric_name_;
 }
 
-const std::string & LinuxProcessCpuMeasurementNode::GetMetricUnit() const
+std::string LinuxProcessCpuMeasurementNode::GetMetricUnit() const
 {
-  static const std::string unit_name{collector_node_constants::kPercentUnitName};
-  return unit_name;
+  return collector_node_constants::kPercentUnitName;
 }
 
 }   // namespace system_metrics_collector

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_cpu_measurement_node.hpp
@@ -94,7 +94,7 @@ protected:
    *
    * @return a string of the name of the measurement unit of this metric
    */
-  const std::string & GetMetricUnit() const override;
+  std::string GetMetricUnit() const override;
 
 private:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.cpp
@@ -92,10 +92,9 @@ std::string LinuxProcessMemoryMeasurementNode::GetMetricName() const
   return pid_ + kMetricName;
 }
 
-const std::string & LinuxProcessMemoryMeasurementNode::GetMetricUnit() const
+std::string LinuxProcessMemoryMeasurementNode::GetMetricUnit() const
 {
-  static const std::string unit_name{collector_node_constants::kPercentUnitName};
-  return unit_name;
+  return collector_node_constants::kPercentUnitName;
 }
 
 uint64_t GetProcessUsedMemory(const std::string & statm_process_file_contents)

--- a/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/linux_process_memory_measurement_node.hpp
@@ -83,7 +83,7 @@ protected:
    *
    * @return a string of the name of the measurement unit of this metric
    */
-  const std::string & GetMetricUnit() const override;
+  std::string GetMetricUnit() const override;
 
 private:
   /**

--- a/system_metrics_collector/src/system_metrics_collector/metric_details_interface.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metric_details_interface.hpp
@@ -1,0 +1,38 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SYSTEM_METRICS_COLLECTOR__METRIC_DETAILS_INTERFACE_HPP_
+#define SYSTEM_METRICS_COLLECTOR__METRIC_DETAILS_INTERFACE_HPP_
+
+#include <string>
+
+namespace system_metrics_collector
+{
+/**
+ * Class to represent a single metric for collection or publication.
+ */
+
+class MetricDetailsInterface
+{
+public:
+  virtual ~MetricDetailsInterface() = default;
+
+  virtual std::string GetMetricName() const = 0;
+
+  virtual std::string GetMetricUnit() const = 0;
+};
+
+}  // namespace system_metrics_collector
+
+#endif  // SYSTEM_METRICS_COLLECTOR__METRIC_DETAILS_INTERFACE_HPP_

--- a/system_metrics_collector/src/system_metrics_collector/metric_details_interface.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metric_details_interface.hpp
@@ -20,7 +20,8 @@
 namespace system_metrics_collector
 {
 /**
- * Class to represent a single metric for collection or publication.
+ * Interface to represent a single metric's name and unit,
+ * which are used for metric message generation and publication.
  */
 
 class MetricDetailsInterface
@@ -28,8 +29,18 @@ class MetricDetailsInterface
 public:
   virtual ~MetricDetailsInterface() = default;
 
+  /**
+   * Return a single metric's name.
+   *
+   * @return a string representing the metric name
+   */
   virtual std::string GetMetricName() const = 0;
 
+  /**
+   * Return a single metric's measurement unit.
+   *
+   * @return a string representing the metric unit
+   */
   virtual std::string GetMetricUnit() const = 0;
 };
 

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -21,6 +21,7 @@
 #include "builtin_interfaces/msg/time.hpp"
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
 
+#include "metric_details_interface.hpp"
 #include "moving_average_statistics/types.hpp"
 
 namespace system_metrics_collector
@@ -49,7 +50,7 @@ metrics_statistics_msgs::msg::MetricsMessage GenerateStatisticMessage(
 /**
  * Simple class to facilitate publishing messages containing statistics data
  */
-class MetricsMessagePublisher
+class MetricsMessagePublisher : virtual public MetricDetailsInterface
 {
 public:
   /**
@@ -63,14 +64,14 @@ public:
    *
    * @return a string of the name for this measured metric
    */
-  virtual std::string GetMetricName() const = 0;
+  std::string GetMetricName() const override = 0;
 
   /**
    * Returns the name of the measurement unit of this metric
    *
    * @return a string of the name of the measurement unit of this metric
    */
-  virtual const std::string & GetMetricUnit() const = 0;
+  std::string GetMetricUnit() const override = 0;
 };
 }  // namespace system_metrics_collector
 

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -21,7 +21,6 @@
 #include "builtin_interfaces/msg/time.hpp"
 #include "metrics_statistics_msgs/msg/metrics_message.hpp"
 
-#include "metric_details_interface.hpp"
 #include "moving_average_statistics/types.hpp"
 
 namespace system_metrics_collector
@@ -50,7 +49,7 @@ metrics_statistics_msgs::msg::MetricsMessage GenerateStatisticMessage(
 /**
  * Simple class to facilitate publishing messages containing statistics data
  */
-class MetricsMessagePublisher : virtual public MetricDetailsInterface
+class MetricsMessagePublisher
 {
 public:
   /**
@@ -58,20 +57,6 @@ public:
    * ROS2 timer per the publish_period)
    */
   virtual void PublishStatisticMessage() = 0;
-
-  /**
-   * Returns the name to use for this metric
-   *
-   * @return a string of the name for this measured metric
-   */
-  std::string GetMetricName() const override = 0;
-
-  /**
-   * Returns the name of the measurement unit of this metric
-   *
-   * @return a string of the name of the measurement unit of this metric
-   */
-  std::string GetMetricUnit() const override = 0;
 };
 }  // namespace system_metrics_collector
 

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -93,6 +93,20 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_error(
     const rclcpp_lifecycle::State & previous_state);
 
+  /**
+   * Return the name of the metric collected.
+   *
+   * @return string reporesenting name of the collected metric
+   */
+  std::string GetMetricName() const override = 0;
+
+  /**
+   * Return the measurement unit of the metric collected.
+   *
+   * @return string representing unit of the metric collected
+   */
+  std::string GetMetricUnit() const override = 0;
+
 protected:
   /**
    * Creates ROS2 timers and a publisher for periodically triggering measurements

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.hpp
@@ -93,20 +93,6 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_error(
     const rclcpp_lifecycle::State & previous_state);
 
-  /**
-   * Return the name of the metric collected.
-   *
-   * @return string reporesenting name of the collected metric
-   */
-  std::string GetMetricName() const override = 0;
-
-  /**
-   * Return the measurement unit of the metric collected.
-   *
-   * @return string representing unit of the metric collected
-   */
-  std::string GetMetricUnit() const override = 0;
-
 protected:
   /**
    * Creates ROS2 timers and a publisher for periodically triggering measurements

--- a/system_metrics_collector/src/topic_statistics_collector/constants.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/constants.hpp
@@ -1,0 +1,32 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOPIC_STATISTICS_COLLECTOR__CONSTANTS_HPP_
+#define TOPIC_STATISTICS_COLLECTOR__CONSTANTS_HPP_
+
+#include <string>
+
+namespace topic_statistics_collector
+{
+
+namespace topic_statistics_constants
+{
+constexpr const char kMsgAgeStatName[] = "message_age";
+constexpr const char kMsgPeriodStatName[] = "message_period";
+constexpr const char kMillisecondUnitName[] = "ms";
+}  // namespace topic_statistics_constants
+
+}  // namespace topic_statistics_collector
+
+#endif  // TOPIC_STATISTICS_COLLECTOR__CONSTANTS_HPP_

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
@@ -135,17 +135,6 @@ public:
     return topic_statistics_constants::kMillisecondUnitName;
   }
 
-  /**
-   * Return the current time using high_resolution_clock.
-   * Defined as virtual for testing and if another clock implementation is desired.
-   *
-   * @return the current time provided by the clock given at construction time
-   */
-  virtual rclcpp::Time GetCurrentTime()
-  {
-    return clock_.now();
-  }
-
 protected:
   bool SetupStart() override
   {

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
@@ -121,7 +121,7 @@ public:
    *
    * @return a string representing message age metric name
    */
-  const std::string GetStatisticName() const override
+  std::string GetMetricName() const override
   {
     return topic_statistics_constants::kMsgAgeStatName;
   }
@@ -130,7 +130,7 @@ public:
    *
    * @return a string representing messager age metric unit
    */
-  const std::string GetStatisticUnit() const override
+  std::string GetMetricUnit() const override
   {
     return topic_statistics_constants::kMillisecondUnitName;
   }

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_age.hpp
@@ -21,6 +21,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "constants.hpp"
 #include "topic_statistics_collector.hpp"
 
 #include "rcl/time.h"
@@ -113,6 +114,36 @@ public:
         system_metrics_collector::Collector::AcceptData(static_cast<double>(age_millis.count()));
       }  // else no valid time to compute age
     }
+  }
+
+  /**
+   * Return message age metric name
+   *
+   * @return a string representing message age metric name
+   */
+  const std::string GetStatisticName() const override
+  {
+    return topic_statistics_constants::kMsgAgeStatName;
+  }
+  /**
+   * Return messge age metric unit
+   *
+   * @return a string representing messager age metric unit
+   */
+  const std::string GetStatisticUnit() const override
+  {
+    return topic_statistics_constants::kMillisecondUnitName;
+  }
+
+  /**
+   * Return the current time using high_resolution_clock.
+   * Defined as virtual for testing and if another clock implementation is desired.
+   *
+   * @return the current time provided by the clock given at construction time
+   */
+  virtual rclcpp::Time GetCurrentTime()
+  {
+    return clock_.now();
   }
 
 protected:

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_period.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_period.hpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <string>
 
+#include "constants.hpp"
 #include "topic_statistics_collector.hpp"
 #include "system_metrics_collector/collector.hpp"
 
@@ -70,6 +71,36 @@ public:
       time_last_message_received_ = now_nanoseconds;
       system_metrics_collector::Collector::AcceptData(static_cast<double>(period.count()));
     }
+  }
+
+  /**
+   * Return message period metric name
+   *
+   * @return a string representing message period metric name
+   */
+  const std::string GetStatisticName() const override
+  {
+    return topic_statistics_constants::kMsgPeriodStatName;
+  }
+  /**
+   * Return message period metric unit
+   *
+   * @return a string representing message period metric name
+   */
+  const std::string GetStatisticUnit() const override
+  {
+    return topic_statistics_constants::kMillisecondUnitName;
+  }
+
+  /**
+   * Return the current time using high_resolution_clock. Defined as virtual for testing
+   * and if another clock implementation is desired.
+   *
+   * @return the current time provided by the clock given at construction time
+   */
+  virtual rclcpp::Time GetCurrentTime()
+  {
+    return clock_.now();
   }
 
 protected:

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_period.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_period.hpp
@@ -78,16 +78,16 @@ public:
    *
    * @return a string representing message period metric name
    */
-  const std::string GetStatisticName() const override
+  std::string GetMetricName() const override
   {
     return topic_statistics_constants::kMsgPeriodStatName;
   }
   /**
    * Return message period metric unit
    *
-   * @return a string representing message period metric name
+   * @return a string representing message period metric unit
    */
-  const std::string GetStatisticUnit() const override
+  std::string GetMetricUnit() const override
   {
     return topic_statistics_constants::kMillisecondUnitName;
   }

--- a/system_metrics_collector/src/topic_statistics_collector/received_message_period.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/received_message_period.hpp
@@ -82,6 +82,7 @@ public:
   {
     return topic_statistics_constants::kMsgPeriodStatName;
   }
+
   /**
    * Return message period metric unit
    *
@@ -90,17 +91,6 @@ public:
   std::string GetMetricUnit() const override
   {
     return topic_statistics_constants::kMillisecondUnitName;
-  }
-
-  /**
-   * Return the current time using high_resolution_clock. Defined as virtual for testing
-   * and if another clock implementation is desired.
-   *
-   * @return the current time provided by the clock given at construction time
-   */
-  virtual rclcpp::Time GetCurrentTime()
-  {
-    return clock_.now();
   }
 
 protected:

--- a/system_metrics_collector/src/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/topic_statistics_collector.hpp
@@ -54,14 +54,14 @@ public:
    *
    * @return a string of the name for this statistic
    */
-  virtual const std::string GetStatisticName() const = 0;
+  std::string GetMetricName() const override = 0;
 
   /**
    * Return the name of the measurement unit of collected statistic
    *
    * @return a string of the name of the measurement unit of this statistic
    */
-  virtual const std::string GetStatisticUnit() const = 0;
+  std::string GetMetricUnit() const override = 0;
 };
 
 }  // namespace topic_statistics_collector

--- a/system_metrics_collector/src/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/topic_statistics_collector.hpp
@@ -48,20 +48,6 @@ public:
   virtual void OnMessageReceived(
     const T & received_message,
     const rcl_time_point_value_t now_nanoseconds) = 0;
-
-  /**
-   * Return the name to use for collected statistic
-   *
-   * @return a string of the name for this statistic
-   */
-  std::string GetMetricName() const override = 0;
-
-  /**
-   * Return the name of the measurement unit of collected statistic
-   *
-   * @return a string of the name of the measurement unit of this statistic
-   */
-  std::string GetMetricUnit() const override = 0;
 };
 
 }  // namespace topic_statistics_collector

--- a/system_metrics_collector/src/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/topic_statistics_collector.hpp
@@ -37,9 +37,9 @@ public:
   TopicStatisticsCollector() = default;
   virtual ~TopicStatisticsCollector() = default;
 
-private:
   /**
    * Handle receiving a single message of type T.
+   *
    * @tparam T the ROS2 message type to collect
    * @param nanoseconds the time the message was received. Any metrics using this time assumes the
    * following 1). the time provided is strictly monotonic 2). the time provided uses the same source
@@ -48,6 +48,20 @@ private:
   virtual void OnMessageReceived(
     const T & received_message,
     const rcl_time_point_value_t now_nanoseconds) = 0;
+
+  /**
+   * Return the name to use for collected statistic
+   *
+   * @return a string of the name for this statistic
+   */
+  virtual const std::string GetStatisticName() const = 0;
+
+  /**
+   * Return the name of the measurement unit of collected statistic
+   *
+   * @return a string of the name of the measurement unit of this statistic
+   */
+  virtual const std::string GetStatisticUnit() const = 0;
 };
 
 }  // namespace topic_statistics_collector

--- a/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
@@ -16,11 +16,17 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include "moving_average_statistics/types.hpp"
 
-
 #include "system_metrics_collector/collector.hpp"
+
+namespace
+{
+constexpr const char kTestMetricName[] = "test_metric_name";
+constexpr const char kTestMetricUnit[] = "test_metric_unit";
+}
 
 /**
  * Simple extension to test basic functionality
@@ -56,6 +62,16 @@ public:
   {
     this->ClearCurrentMeasurements();
     return true;
+  }
+
+  std::string GetMetricName() const override
+  {
+    return kTestMetricName;
+  }
+
+  std::string GetMetricUnit() const override
+  {
+    return kTestMetricUnit;
   }
 };
 

--- a/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_collector.cpp
@@ -139,3 +139,8 @@ TEST_F(CollectorTestFixure, TestStartAndStop) {
   ASSERT_TRUE(test_collector_->Stop());
   ASSERT_FALSE(test_collector_->IsStarted());
 }
+
+TEST_F(CollectorTestFixure, TestGetMetricNameAndUnit) {
+  EXPECT_FALSE(test_collector_->GetMetricName().empty());
+  EXPECT_FALSE(test_collector_->GetMetricUnit().empty());
+}

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_memory_measurement_node.cpp
@@ -54,7 +54,7 @@ public:
     return LinuxProcessMemoryMeasurementNode::GetMetricName();
   }
 
-  const std::string & GetMetricUnit() const override
+  std::string GetMetricUnit() const override
   {
     return LinuxProcessMemoryMeasurementNode::GetMetricUnit();
   }

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -95,10 +95,9 @@ private:
     return kTestMetricName;
   }
 
-  const std::string & GetMetricUnit() const override
+  std::string GetMetricUnit() const override
   {
-    static const std::string unit_name{kTestMetricUnit};
-    return unit_name;
+    return kTestMetricUnit;
   }
 
   std::atomic<int> times_measured_{0};

--- a/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_periodic_measurement_node.cpp
@@ -68,6 +68,16 @@ public:
     return publisher_ != nullptr && publisher_->is_activated();
   }
 
+  std::string GetMetricName() const override
+  {
+    return kTestMetricName;
+  }
+
+  std::string GetMetricUnit() const override
+  {
+    return kTestMetricUnit;
+  }
+
 private:
   /**
    * Test measurement for the fixture.
@@ -88,16 +98,6 @@ private:
   void PublishStatisticMessage() override
   {
     ++times_published_;
-  }
-
-  std::string GetMetricName() const override
-  {
-    return kTestMetricName;
-  }
-
-  std::string GetMetricUnit() const override
-  {
-    return kTestMetricUnit;
   }
 
   std::atomic<int> times_measured_{0};
@@ -239,6 +239,11 @@ TEST_F(PeriodicMeasurementTestFixure, TestStartAndStop) {
   int times_published = test_periodic_measurer_->GetNumPublished();
   ASSERT_EQ(
     test_constants::kTestDuration.count() / kDontPublishDuringTest.count(), times_published);
+}
+
+TEST_F(PeriodicMeasurementTestFixure, TestGetMetricNameAndUnit) {
+  ASSERT_FALSE(test_periodic_measurer_->GetMetricName().empty());
+  ASSERT_FALSE(test_periodic_measurer_->GetMetricUnit().empty());
 }
 
 TEST_F(PeriodicMeasurementTestFixure, TestLifecycleManually) {

--- a/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
@@ -138,7 +138,7 @@ TEST(ReceivedMessageAgeTest, TestAgeMeasurement) {
 }
 
 TEST(ReceivedMessageAgeTest, TestGetStatNameAndUnit) {
-  TestReceivedMessageAgeCollector test_collector{};
+  topic_statistics_collector::ReceivedMessageAgeCollector<sensor_msgs::msg::Imu> test_collector{};
 
   EXPECT_FALSE(test_collector.GetMetricName().empty());
   EXPECT_FALSE(test_collector.GetMetricUnit().empty());

--- a/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
@@ -140,10 +140,6 @@ TEST(ReceivedMessageAgeTest, TestAgeMeasurement) {
 TEST(ReceivedMessageAgeTest, TestGetStatNameAndUnit) {
   TestReceivedMessageAgeCollector test_collector{};
 
-  EXPECT_EQ(
-    test_collector.GetStatisticName(),
-    topic_statistics_collector::topic_statistics_constants::kMsgAgeStatName);
-  EXPECT_EQ(
-    test_collector.GetStatisticUnit(),
-    topic_statistics_collector::topic_statistics_constants::kMillisecondUnitName);
+  EXPECT_FALSE(test_collector.GetMetricName().empty());
+  EXPECT_FALSE(test_collector.GetMetricUnit().empty());
 }

--- a/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_received_message_age.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <string>
 
+#include "topic_statistics_collector/constants.hpp"
 #include "topic_statistics_collector/received_message_age.hpp"
 
 #include "rcl/time.h"
@@ -134,4 +135,15 @@ TEST(ReceivedMessageAgeTest, TestAgeMeasurement) {
   EXPECT_EQ(kExpectedMinMilliseconds, stats.min);
   EXPECT_EQ(kExpectedMaxMilliseconds, stats.max);
   EXPECT_DOUBLE_EQ(kExpectedStandardDeviation, stats.standard_deviation);
+}
+
+TEST(ReceivedMessageAgeTest, TestGetStatNameAndUnit) {
+  TestReceivedMessageAgeCollector test_collector{};
+
+  EXPECT_EQ(
+    test_collector.GetStatisticName(),
+    topic_statistics_collector::topic_statistics_constants::kMsgAgeStatName);
+  EXPECT_EQ(
+    test_collector.GetStatisticUnit(),
+    topic_statistics_collector::topic_statistics_constants::kMillisecondUnitName);
 }

--- a/system_metrics_collector/test/topic_statistics_collector/test_received_message_period.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_received_message_period.cpp
@@ -79,10 +79,6 @@ TEST(ReceivedMessagePeriodTest, TestPeriodMeasurement) {
 TEST(ReceivedMessagePeriodTest, TestGetStatNameAndUnit) {
   TestReceivedMessagePeriodCollector test_collector{};
 
-  EXPECT_EQ(
-    test_collector.GetStatisticName(),
-    topic_statistics_collector::topic_statistics_constants::kMsgPeriodStatName);
-  EXPECT_EQ(
-    test_collector.GetStatisticUnit(),
-    topic_statistics_collector::topic_statistics_constants::kMillisecondUnitName);
+  EXPECT_FALSE(test_collector.GetMetricName().empty());
+  EXPECT_FALSE(test_collector.GetMetricUnit().empty());
 }

--- a/system_metrics_collector/test/topic_statistics_collector/test_received_message_period.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_received_message_period.cpp
@@ -77,8 +77,8 @@ TEST(ReceivedMessagePeriodTest, TestPeriodMeasurement) {
 }
 
 TEST(ReceivedMessagePeriodTest, TestGetStatNameAndUnit) {
-  TestReceivedMessagePeriodCollector test_collector{};
+  topic_statistics_collector::ReceivedMessagePeriodCollector<int> test{};
 
-  EXPECT_FALSE(test_collector.GetMetricName().empty());
-  EXPECT_FALSE(test_collector.GetMetricUnit().empty());
+  EXPECT_FALSE(test.GetMetricName().empty());
+  EXPECT_FALSE(test.GetMetricUnit().empty());
 }

--- a/system_metrics_collector/test/topic_statistics_collector/test_received_message_period.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_received_message_period.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 
 #include "moving_average_statistics/types.hpp"
+#include "topic_statistics_collector/constants.hpp"
 #include "topic_statistics_collector/received_message_period.hpp"
 
 #include "rcl/time.h"
@@ -73,4 +74,15 @@ TEST(ReceivedMessagePeriodTest, TestPeriodMeasurement) {
   EXPECT_EQ(kExpectedMinMilliseconds, stats.min);
   EXPECT_EQ(kExpectedMaxMilliseconds, stats.max);
   EXPECT_EQ(kExpectedStandardDeviation, stats.standard_deviation);
+}
+
+TEST(ReceivedMessagePeriodTest, TestGetStatNameAndUnit) {
+  TestReceivedMessagePeriodCollector test_collector{};
+
+  EXPECT_EQ(
+    test_collector.GetStatisticName(),
+    topic_statistics_collector::topic_statistics_constants::kMsgPeriodStatName);
+  EXPECT_EQ(
+    test_collector.GetStatisticUnit(),
+    topic_statistics_collector::topic_statistics_constants::kMillisecondUnitName);
 }


### PR DESCRIPTION
Changes to `topic_statistics_collector` interface. Needed for https://github.com/ros-tooling/system_metrics_collector/pull/112.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>