### PR TITLE
Move message generation function to libstatistics_collector

### DIFF
--- a/libstatistics_collector/CMakeLists.txt
+++ b/libstatistics_collector/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(metrics_statistics_msgs REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -41,12 +42,13 @@ rosidl_generate_interfaces(libstatistics_collector_test_msgs
 include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED
-  src/libstatistics_collector/moving_average_statistics/moving_average.cpp
-  src/libstatistics_collector/moving_average_statistics/types.cpp
   src/libstatistics_collector/collector/collector.cpp
-)
+  src/libstatistics_collector/collector/generate_statistics_message.cpp
+  src/libstatistics_collector/moving_average_statistics/moving_average.cpp
+  src/libstatistics_collector/moving_average_statistics/types.cpp)
 
 ament_target_dependencies(${PROJECT_NAME}
+  metrics_statistics_msgs
   rcl
   rcpputils)
 

--- a/libstatistics_collector/include/libstatistics_collector/collector/generate_statistics_message.hpp
+++ b/libstatistics_collector/include/libstatistics_collector/collector/generate_statistics_message.hpp
@@ -1,0 +1,53 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSTATISTICS_COLLECTOR__COLLECTOR__GENERATE_STATISTICS_MESSAGE_HPP_
+#define LIBSTATISTICS_COLLECTOR__COLLECTOR__GENERATE_STATISTICS_MESSAGE_HPP_
+
+#include <string>
+
+#include "builtin_interfaces/msg/time.hpp"
+#include "metrics_statistics_msgs/msg/metrics_message.hpp"
+
+#include "libstatistics_collector/moving_average_statistics/types.hpp"
+
+namespace libstatistics_collector
+{
+namespace collector
+{
+
+/**
+ * Return a valid MetricsMessage ready to be published to a ROS topic
+ *
+ * @param node_name the name of the node that the data originates from
+ * @param metric_name the name of the metric ("cpu_usage", "memory_usage", etc.)
+ * @param unit name of the unit ("percentage", "mb", etc.)
+ * @param window_start measurement window start time
+ * @param window_stop measurement window end time
+ * @param data statistics derived from the measurements made in the window
+ * @return a MetricsMessage containing the statistics in the data parameter
+ */
+metrics_statistics_msgs::msg::MetricsMessage GenerateStatisticMessage(
+  const std::string & node_name,
+  const std::string & metric_name,
+  const std::string & unit,
+  const builtin_interfaces::msg::Time window_start,
+  const builtin_interfaces::msg::Time window_stop,
+  const libstatistics_collector::moving_average_statistics::StatisticData & data
+);
+
+}  // namespace collector
+}  // namespace libstatistics_collector
+
+#endif  // LIBSTATISTICS_COLLECTOR__COLLECTOR__GENERATE_STATISTICS_MESSAGE_HPP_

--- a/libstatistics_collector/package.xml
+++ b/libstatistics_collector/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>metrics_statistics_msgs</depend>
   <depend>rcl</depend>
   <depend>rcpputils</depend>
 

--- a/libstatistics_collector/src/libstatistics_collector/collector/generate_statistics_message.cpp
+++ b/libstatistics_collector/src/libstatistics_collector/collector/generate_statistics_message.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "metrics_message_publisher.hpp"
+#include "libstatistics_collector/collector/generate_statistics_message.hpp"
 
 #include <string>
 #include <utility>
 
 #include "metrics_statistics_msgs/msg/statistic_data_type.hpp"
 
+namespace libstatistics_collector
+{
+namespace collector
+{
+
 using metrics_statistics_msgs::msg::MetricsMessage;
 using metrics_statistics_msgs::msg::StatisticDataPoint;
 using metrics_statistics_msgs::msg::StatisticDataType;
-
-namespace system_metrics_collector
-{
 
 MetricsMessage GenerateStatisticMessage(
   const std::string & node_name,
@@ -67,4 +69,5 @@ MetricsMessage GenerateStatisticMessage(
   return msg;
 }
 
-}  // namespace system_metrics_collector
+}  // namespace collector
+}  // namespace libstatistics_collector

--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -49,7 +49,6 @@ rosidl_generate_interfaces(system_metrics_collector_test_msgs
 include_directories(src)
 
 add_library(${PROJECT_NAME} SHARED
-  src/system_metrics_collector/metrics_message_publisher.cpp
   src/system_metrics_collector/linux_cpu_measurement_node.cpp
   src/system_metrics_collector/linux_memory_measurement_node.cpp
   src/system_metrics_collector/linux_process_cpu_measurement_node.cpp

--- a/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
+++ b/system_metrics_collector/src/system_metrics_collector/metrics_message_publisher.hpp
@@ -27,26 +27,6 @@ namespace system_metrics_collector
 {
 
 /**
- * Return a valid MetricsMessage ready to be published to a ROS topic
- *
- * @param node_name the name of the node that the data originates from
- * @param metric_name the name of the metric ("cpu_usage", "memory_usage", etc.)
- * @param unit name of the unit ("percentage", "mb", etc.)
- * @param window_start measurement window start time
- * @param window_stop measurement window end time
- * @param data statistics derived from the measurements made in the window
- * @return a MetricsMessage containing the statistics in the data parameter
- */
-metrics_statistics_msgs::msg::MetricsMessage GenerateStatisticMessage(
-  const std::string & node_name,
-  const std::string & metric_name,
-  const std::string & unit,
-  const builtin_interfaces::msg::Time window_start,
-  const builtin_interfaces::msg::Time window_stop,
-  const libstatistics_collector::moving_average_statistics::StatisticData & data
-);
-
-/**
  * Simple class to facilitate publishing messages containing statistics data
  */
 class MetricsMessagePublisher

--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -23,6 +23,8 @@
 #include "constants.hpp"
 #include "metrics_message_publisher.hpp"
 
+#include "libstatistics_collector/collector/generate_statistics_message.hpp"
+
 #include "rclcpp/rclcpp.hpp"
 
 using metrics_statistics_msgs::msg::MetricsMessage;
@@ -178,7 +180,7 @@ void PeriodicMeasurementNode::PublishStatisticMessage()
   assert(publisher_ != nullptr);
   assert(publisher_->is_activated());
 
-  const auto msg = GenerateStatisticMessage(
+  const auto msg = libstatistics_collector::collector::GenerateStatisticMessage(
     get_name(),
     GetMetricName(),
     GetMetricUnit(),

--- a/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
@@ -25,9 +25,11 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rcpputils/asserts.hpp"
 
+#include "libstatistics_collector/collector/generate_statistics_message.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_age.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_period.hpp"
 #include "libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp"
+
 #include "parameter_utils.hpp"
 #include "system_metrics_collector/constants.hpp"
 #include "system_metrics_collector/metrics_message_publisher.hpp"
@@ -268,7 +270,7 @@ private:
     this->window_start_ = this->now();
 
     for (const auto & collector : statistics_collectors_) {
-      const auto msg = system_metrics_collector::GenerateStatisticMessage(
+      const auto msg = libstatistics_collector::collector::GenerateStatisticMessage(
         get_name(),
         collector->GetMetricName(),
         collector->GetMetricUnit(),

--- a/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
@@ -22,6 +22,8 @@
 
 #include "system_metrics_collector/metrics_message_publisher.hpp"
 
+#include "libstatistics_collector/collector/generate_statistics_message.hpp"
+
 namespace
 {
 using libstatistics_collector::moving_average_statistics::StatisticData;
@@ -51,7 +53,7 @@ TEST(MetricsMessagePublisherTest, TestGenerateMessage) {
   data.standard_deviation = dist(gen);
   data.sample_count = dist(gen);
 
-  MetricsMessage msg = system_metrics_collector::GenerateStatisticMessage(
+  MetricsMessage msg = libstatistics_collector::collector::GenerateStatisticMessage(
     kTestNodeName, kTestMeasurementType, kTestMeasurementUnit, time1, time2, data);
 
   EXPECT_EQ(kTestNodeName, msg.measurement_source_name);

--- a/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_metrics_message_publisher.cpp
@@ -53,7 +53,7 @@ TEST(MetricsMessagePublisherTest, TestGenerateMessage) {
   data.standard_deviation = dist(gen);
   data.sample_count = dist(gen);
 
-  MetricsMessage msg = libstatistics_collector::collector::GenerateStatisticMessage(
+  const auto msg = libstatistics_collector::collector::GenerateStatisticMessage(
     kTestNodeName, kTestMeasurementType, kTestMeasurementUnit, time1, time2, data);
 
   EXPECT_EQ(kTestNodeName, msg.measurement_source_name);


### PR DESCRIPTION
This PR moves [#224](https://github.com/ros-tooling/aws-roadmap/issues/224) to done, by moving a generic utility function to the shared library. Topic Statistics needs this function (as well as system metrics) in order to generate and publish a message.



Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>