### PR TITLE
Add topic statistics executable, launch file and e2e test

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -91,6 +91,11 @@ add_executable(dummy_talker src/topic_statistics_collector/dummy_talker.cpp)
 target_link_libraries(dummy_talker system_metrics_collector)
 ament_target_dependencies(dummy_talker)
 
+add_executable(topic_statistics_node src/topic_statistics_collector/topic_statistics_node.cpp)
+target_link_libraries(topic_statistics_node system_metrics_collector)
+ament_target_dependencies(topic_statistics_node)
+
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
@@ -147,6 +152,7 @@ endif()
 # To enable use of dummy_message.hpp in executables
 rosidl_target_interfaces(test_subscriber_topic_statistics system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 rosidl_target_interfaces(dummy_talker system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
+rosidl_target_interfaces(topic_statistics_node system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 
 # Install launch files
 install(DIRECTORY
@@ -175,6 +181,12 @@ install(TARGETS
 
 install(TARGETS
   dummy_talker
+  DESTINATION
+  lib/${PROJECT_NAME}
+)
+
+install(TARGETS
+  topic_statistics_node
   DESTINATION
   lib/${PROJECT_NAME}
 )

--- a/system_metrics_collector/share/system_metrics_collector/examples/topic_statistics_node.launch.py
+++ b/system_metrics_collector/share/system_metrics_collector/examples/topic_statistics_node.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     ld.add_action(DeclareLaunchArgument(
         MONITORED_TOPIC_NAME,
         default_value=DEFAULT_MONITORED_TOPIC_NAME,
-        description='The topic for which to measure message metrics'))
+        description='The topic to subscribe to in order to measure message metrics'))
     ld.add_action(DeclareLaunchArgument(
         PUBLISH_PERIOD_IN_MS,
         default_value=DEFAULT_PUBLISH_PERIOD_IN_MS,

--- a/system_metrics_collector/share/system_metrics_collector/examples/topic_statistics_node.launch.py
+++ b/system_metrics_collector/share/system_metrics_collector/examples/topic_statistics_node.launch.py
@@ -1,0 +1,78 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example launch file demonstrating topic statistics node configuration.
+
+This launch file uses the topic statistics subscriber to start the collector
+node and demonstrates how to configure the node's parameters.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+# Launch argument names
+COLLECTOR_NODE_NAME = 'topic_statistics_node_name'
+MONITORED_TOPIC_NAME = 'collect_topic_name'
+PUBLISH_PERIOD_IN_MS = 'publish_period'
+PUBLISH_TOPIC_NAME = 'publish_topic_name'
+
+# Default argument values
+DEFAULT_COLLECTOR_NODE_NAME = 'topic_stats_collector'
+DEFAULT_MONITORED_TOPIC_NAME = 'dummy_topic'
+DEFAULT_PUBLISH_PERIOD_IN_MS = '30000'
+DEFAULT_PUBLISH_TOPIC = 'system_metrics'
+
+
+def generate_launch_description():
+    """Launch topic statistics collector nodes."""
+    ld = LaunchDescription()
+
+    ld.add_action(DeclareLaunchArgument(
+        COLLECTOR_NODE_NAME,
+        default_value=DEFAULT_COLLECTOR_NODE_NAME,
+        description='A name for the node that collects topic statistics'))
+    ld.add_action(DeclareLaunchArgument(
+        MONITORED_TOPIC_NAME,
+        default_value=DEFAULT_MONITORED_TOPIC_NAME,
+        description='The topic for which to measure message metrics'))
+    ld.add_action(DeclareLaunchArgument(
+        PUBLISH_PERIOD_IN_MS,
+        default_value=DEFAULT_PUBLISH_PERIOD_IN_MS,
+        description='The period (in ms) between each subsequent metrics message published'
+                    ' by the collector node'))
+    ld.add_action(DeclareLaunchArgument(
+        PUBLISH_TOPIC_NAME,
+        default_value=DEFAULT_PUBLISH_TOPIC,
+        description='The name of the topic to which the collector nodes should publish'))
+
+    node_parameters = [
+        {MONITORED_TOPIC_NAME: LaunchConfiguration(MONITORED_TOPIC_NAME)},
+        {PUBLISH_TOPIC_NAME: LaunchConfiguration(PUBLISH_TOPIC_NAME)},
+        {PUBLISH_PERIOD_IN_MS: LaunchConfiguration(PUBLISH_PERIOD_IN_MS)}]
+
+    """Run topic statistics collector node using launch."""
+    ld.add_action(
+        Node(
+            package='system_metrics_collector',
+            node_executable='topic_statistics_node',
+            name=LaunchConfiguration(COLLECTOR_NODE_NAME),
+            parameters=node_parameters,
+            remappings=[('system_metrics', LaunchConfiguration(PUBLISH_TOPIC_NAME))],
+            output='screen')
+        )
+
+    return ld

--- a/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
@@ -99,6 +99,7 @@ public:
 
     auto callback = [this](typename T::SharedPtr received_message) {
         for (const auto & collector : statistics_collectors_) {
+          RCLCPP_DEBUG(this->get_logger(), collector->GetStatusString());
           collector->OnMessageReceived(*received_message, this->LifecycleNode::now().nanoseconds());
         }
       };

--- a/system_metrics_collector/src/topic_statistics_collector/topic_statistics_node.cpp
+++ b/system_metrics_collector/src/topic_statistics_collector/topic_statistics_node.cpp
@@ -1,0 +1,53 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "libstatistics_collector/topic_statistics_collector/constants.hpp"
+#include "subscriber_topic_statistics.hpp"
+#include "system_metrics_collector/msg/dummy_message.hpp"
+
+/**
+ * An entry point that starts the topic statistics collector node.
+ */
+
+int main(int argc, char ** argv)
+{
+  namespace constants =
+    libstatistics_collector::topic_statistics_collector::topic_statistics_constants;
+
+  rclcpp::init(argc, argv);
+
+  const auto options = rclcpp::NodeOptions().append_parameter_override(
+    constants::kCollectStatsTopicNameParam,
+    "dummy_data");
+  const auto topic_stats_node =
+    std::make_shared<topic_statistics_collector::SubscriberTopicStatisticsNode<
+        system_metrics_collector::msg::DummyMessage>>("topic_statistics_collector", options);
+
+  rclcpp::executors::MultiThreadedExecutor ex;
+  topic_stats_node->configure();
+  topic_stats_node->activate();
+
+  ex.add_node(topic_stats_node->get_node_base_interface());
+  ex.spin();
+
+  rclcpp::shutdown();
+  topic_stats_node->deactivate();
+
+  return 0;
+}

--- a/test/run_e2e_test.sh
+++ b/test/run_e2e_test.sh
@@ -11,5 +11,6 @@ TEST_DIR=ros_ws/src/system_metrics_collector/test
 # source the ROS2 installation
 source "$ROS_WS_DIR/setup.bash" && source "$ROS_WS_DIR/local_setup.bash"
 
-# run the e2e test
+# run the e2e tests
 python3 "$TEST_DIR/system_metrics_e2e_test.py"
+python3 "$TEST_DIR/topic_statistics_e2e_test.py"

--- a/test/topic_statistics_e2e_test.py
+++ b/test/topic_statistics_e2e_test.py
@@ -1,0 +1,103 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End to end tests for the topic statistics collection.
+
+These tests launch the dummy_talker and topic_statistics_node nodes and use
+ROS2 commands to inspect if the expected nodes are active and publishing data.
+
+To run these tests ensure that ROS2 is installed, with the
+system_metrics_collector package the relevant setup.bash has been sourced.
+"""
+
+import logging
+import signal
+import subprocess
+import sys
+
+import rclpy
+
+import test_helpers
+
+
+# Expected outputs
+EXPECTED_LIFECYCLE_NODES = frozenset(['/topic_stats_collector'])
+EXPECTED_REGULAR_NODES = frozenset(['/dummy_talker'])
+EXPECTED_LIFECYCLE_STATE = 'active [3]'
+EXPECTED_TOPIC = '/system_metrics'
+# Commands to execute
+LAUNCH_TALKER = 'ros2 launch system_metrics_collector dummy_talker.launch.py'
+LAUNCH_COLLECTOR = 'ros2 launch system_metrics_collector topic_statistics_node.launch.py'
+# Test constants
+TIMEOUT_SECONDS = 30
+RETURN_VALUE_FAILURE = 1
+RETURN_VALUE_SUCCESS = 0
+EXPECTED_NUMBER_OF_MESSAGES_TO_RECEIVE = 5
+
+
+def main(args=None) -> int:
+    """
+    Run the topic statistics collector e2e tests. This exits on the first failure encountered.
+
+    :param args:
+    :return: 0 if all tests pass, 1 if any fail
+    """
+    try:
+        rclpy.init()
+
+        return_value = RETURN_VALUE_FAILURE
+
+        split_command = LAUNCH_TALKER.split()
+        logging.debug('Executing: %s', split_command)
+        talker_process = subprocess.Popen(split_command)
+
+        split_command = LAUNCH_COLLECTOR.split()
+        logging.debug('Executing: %s', split_command)
+        listener_process = subprocess.Popen(split_command)
+
+        logging.info('====Starting tests====')
+        test_helpers.check_for_expected_nodes(
+            list(EXPECTED_REGULAR_NODES) + list(EXPECTED_LIFECYCLE_NODES))
+        test_helpers.check_lifecycle_node_enumeration(EXPECTED_LIFECYCLE_NODES)
+        test_helpers.check_lifecycle_node_state(EXPECTED_LIFECYCLE_NODES, EXPECTED_LIFECYCLE_STATE)
+        test_helpers.check_for_expected_topic(EXPECTED_TOPIC)
+        test_helpers.check_for_statistic_publications(
+          EXPECTED_LIFECYCLE_NODES, EXPECTED_NUMBER_OF_MESSAGES_TO_RECEIVE, EXPECTED_TOPIC)
+        logging.info('====All tests succeeded====')
+
+        return_value = RETURN_VALUE_SUCCESS
+
+    except test_helpers.SystemMetricsEnd2EndTestException:
+        logging.error('Test failure: ', exc_info=True)
+
+    except Exception:
+        logging.error('Caught unrelated exception: ', exc_info=True)
+
+    finally:
+        logging.debug('Finished tests. Sending SIGINT')
+        talker_process.send_signal(signal.SIGINT)
+        listener_process.send_signal(signal.SIGINT)
+        talker_process.wait(timeout=TIMEOUT_SECONDS)
+        listener_process.wait(timeout=TIMEOUT_SECONDS)
+        rclpy.shutdown()
+
+    return return_value
+
+
+if __name__ == '__main__':
+    test_helpers.setup_logger()
+    test_output = main()
+    logging.debug('exiting with test_output=%s', test_output)
+    sys.exit(test_output)


### PR DESCRIPTION
* Add executable to start a topic statistics collector node
* Add launch file to launch the node
* These are meant to be used in topic_statistics_collector e2e test -> added the new e2e test to this PR

Closes https://github.com/ros-tooling/aws-roadmap/issues/197

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>