### PR TITLE
Fix test subscriber failures

### DIFF
--- a/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
@@ -265,6 +265,7 @@ private:
   {
     rcpputils::check_true(publisher_ != nullptr);
     rcpputils::check_true(publisher_->is_activated());
+
     this->window_start_ = this->now();
 
     for (const auto & collector : statistics_collectors_) {

--- a/system_metrics_collector/test/system_metrics_collector/test_functions.hpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_functions.hpp
@@ -153,13 +153,11 @@ class MetricsMessageSubscriber : public rclcpp::Node, public PromiseSetter
 {
 public:
   /**
-   *
+   * Constucts a MetricsMessageSubscriber
    * @param name the node name
    * @param name the topic name
-   * @param promise_trigger the PromiseSetter::SetPromise will be called when the number of messages
-   * received is >= the promise_trigger.
    */
-  MetricsMessageSubscriber(const std::string & name, const std::string topic_name)
+  MetricsMessageSubscriber(const std::string & name, const std::string & topic_name)
   : rclcpp::Node(name)
   {
     auto callback = [this](MetricsMessage::UniquePtr msg) {
@@ -182,6 +180,10 @@ public:
     return last_received_message_;
   }
 
+  /**
+   * Return the number of messages received
+   * @return
+   */
   int GetNumberOfMessagesReceived() const
   {
     return num_messages_received_;

--- a/system_metrics_collector/test/system_metrics_collector/test_functions.hpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_functions.hpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -152,24 +153,39 @@ private:
 class MetricsMessageSubscriber : public rclcpp::Node, public PromiseSetter
 {
 public:
-  explicit MetricsMessageSubscriber(const std::string & name)
+
+  /**
+   *
+   * @param name the node name
+   * @param name the topic name
+   * @param promise_trigger the PromiseSetter::SetPromise will be called when the number of messages
+   * received is >= the promise_trigger.
+   */
+  MetricsMessageSubscriber(const std::string & name, const std::string topic_name)
   : rclcpp::Node(name)
   {
-    auto callback = [this](MetricsMessage::UniquePtr msg) {this->MetricsMessageCallback(*msg);};
+    auto callback = [this](MetricsMessage::UniquePtr msg) {
+      this->MetricsMessageCallback(*msg);};
     subscription_ = create_subscription<MetricsMessage,
         std::function<void(MetricsMessage::UniquePtr)>>(
-      system_metrics_collector::collector_node_constants::kStatisticsTopicName,
-      0 /*history_depth*/, callback);
+      topic_name,
+      0 /*history_depth*/,
+      callback);
   }
 
   /**
    * Acquires a mutex in order to get the last message received member.
    * @return the last message received
    */
-  MetricsMessage GetLastReceivedMessage()
+  MetricsMessage GetLastReceivedMessage() const
   {
     std::unique_lock<std::mutex> ulock{mutex_};
     return last_received_message_;
+  }
+
+  int GetNumberOfMessagesReceived() const
+  {
+    return num_messages_received_;
   }
 
 private:
@@ -181,6 +197,7 @@ private:
   void MetricsMessageCallback(const MetricsMessage & msg)
   {
     std::unique_lock<std::mutex> ulock{mutex_};
+    ++num_messages_received_;
     last_received_message_ = msg;
     PromiseSetter::SetPromise();
   }
@@ -188,6 +205,7 @@ private:
   MetricsMessage last_received_message_;
   rclcpp::Subscription<MetricsMessage>::SharedPtr subscription_;
   mutable std::mutex mutex_;
+  std::atomic<int> num_messages_received_{0};
 };
 
 }  // namespace test_functions

--- a/system_metrics_collector/test/system_metrics_collector/test_functions.hpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_functions.hpp
@@ -181,8 +181,8 @@ public:
   }
 
   /**
-   * Return the number of messages received
-   * @return
+   * Return the number of messages received by this subscriber
+   * @return the number of messages received by the subscriber callback
    */
   int GetNumberOfMessagesReceived() const
   {

--- a/system_metrics_collector/test/system_metrics_collector/test_functions.hpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_functions.hpp
@@ -17,7 +17,6 @@
 
 #include <gtest/gtest.h>
 
-#include <atomic>
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -153,7 +152,6 @@ private:
 class MetricsMessageSubscriber : public rclcpp::Node, public PromiseSetter
 {
 public:
-
   /**
    *
    * @param name the node name
@@ -165,7 +163,8 @@ public:
   : rclcpp::Node(name)
   {
     auto callback = [this](MetricsMessage::UniquePtr msg) {
-      this->MetricsMessageCallback(*msg);};
+        this->MetricsMessageCallback(*msg);
+      };
     subscription_ = create_subscription<MetricsMessage,
         std::function<void(MetricsMessage::UniquePtr)>>(
       topic_name,

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -262,10 +262,8 @@ TEST_F(LinuxCpuMeasurementTestFixture, TestPublishMessage)
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, test_measure_linux_cpu_->get_current_state().id());
   ASSERT_TRUE(test_measure_linux_cpu_->IsStarted());
 
-  //
   // spin the node while activated and use the node's future to halt
   // after the first published message
-  //
   ex.spin_until_future_complete(
     test_receive_measurements->GetFuture(), test_constants::kPublishTestTimeout);
   EXPECT_EQ(test_receive_measurements->GetNumberOfMessagesReceived(), 1);

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_cpu_measurement.cpp
@@ -245,7 +245,8 @@ TEST_F(LinuxCpuMeasurementTestFixture, TestPublishMessage)
     test_measure_linux_cpu_->get_current_state().id());
 
   const auto test_receive_measurements = std::make_shared<test_functions::MetricsMessageSubscriber>(
-    "test_receive_measurements");
+    "test_receive_measurements",
+    system_metrics_collector::collector_node_constants::kStatisticsTopicName);
 
   rclcpp::executors::SingleThreadedExecutor ex;
   ex.add_node(test_measure_linux_cpu_->get_node_base_interface());
@@ -267,6 +268,7 @@ TEST_F(LinuxCpuMeasurementTestFixture, TestPublishMessage)
   //
   ex.spin_until_future_complete(
     test_receive_measurements->GetFuture(), test_constants::kPublishTestTimeout);
+  EXPECT_EQ(test_receive_measurements->GetNumberOfMessagesReceived(), 1);
 
   // generate expected data: expectation is that 6 samples are taken within the publish
   // time frame

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_memory_measurement.cpp
@@ -265,7 +265,8 @@ TEST_F(LinuxMemoryMeasurementTestFixture, TestPublishMessage)
   test_measure_linux_memory_->SetTestVector(kSamples);
 
   const auto test_receive_measurements = std::make_shared<test_functions::MetricsMessageSubscriber>(
-    "test_receive_measurements");
+    "test_receive_measurements",
+    system_metrics_collector::collector_node_constants::kStatisticsTopicName);
 
   rclcpp::executors::SingleThreadedExecutor ex;
   ex.add_node(test_measure_linux_memory_->get_node_base_interface());
@@ -287,6 +288,7 @@ TEST_F(LinuxMemoryMeasurementTestFixture, TestPublishMessage)
   //
   ex.spin_until_future_complete(
     test_receive_measurements->GetFuture(), test_constants::kPublishTestTimeout);
+  EXPECT_EQ(test_receive_measurements->GetNumberOfMessagesReceived(), 1);
 
   // generate expected data, expectation is that all of kSamples was measured
   // before the message was published

--- a/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
+++ b/system_metrics_collector/test/system_metrics_collector/test_linux_process_cpu_measurement_node.cpp
@@ -265,7 +265,8 @@ TEST_F(LinuxProcessCpuMeasurementTestFixture, TestPublishMessage)
     test_measure_linux_process_cpu_->get_current_state().id());
 
   const auto test_receive_measurements = std::make_shared<test_functions::MetricsMessageSubscriber>(
-    "test_receive_measurements");
+    "test_receive_measurements",
+    system_metrics_collector::collector_node_constants::kStatisticsTopicName);
 
   rclcpp::executors::SingleThreadedExecutor ex;
   ex.add_node(test_measure_linux_process_cpu_->get_node_base_interface());
@@ -289,6 +290,7 @@ TEST_F(LinuxProcessCpuMeasurementTestFixture, TestPublishMessage)
   //
   ex.spin_until_future_complete(
     test_receive_measurements->GetFuture(), test_constants::kPublishTestTimeout);
+  EXPECT_EQ(test_receive_measurements->GetNumberOfMessagesReceived(), 1);
 
   // generate expected data: expectation is that 6 samples are taken within the publish
   // time frame

--- a/system_metrics_collector/test/topic_statistics_collector/test_subscriber_topic_statistics.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_subscriber_topic_statistics.cpp
@@ -41,7 +41,7 @@ using DummyMessage = system_metrics_collector::msg::DummyMessage;
 
 constexpr const int64_t kAnyTimestamp = 1000000;
 constexpr const std::chrono::seconds kTestDuration{10};
-constexpr const std::chrono::milliseconds kImuPublishPeriod{100};
+constexpr const std::chrono::milliseconds kDummyPublishPeriod{100};
 constexpr const std::chrono::milliseconds kTopicPublishPeriod{1000};
 constexpr const char kStatsCollectorNodeName[] = "topic_stats_node";
 constexpr const char kTestTopicName[] = "/test_topic";
@@ -116,7 +116,7 @@ public:
     return data;
   }
 
-  std::vector<StatisticData> GetPublishedCollectorData() const
+  const std::vector<StatisticData> & GetPublishedCollectorData() const
   {
     return last_published_data_;
   }
@@ -147,7 +147,7 @@ public:
   {
     publisher_ = create_publisher<DummyMessage>(kTestTopicName, 10);
     publish_timer_ = this->create_wall_timer(
-      kImuPublishPeriod, [this]() {
+      kDummyPublishPeriod, [this]() {
         this->PublishMessage();
       });
   }

--- a/system_metrics_collector/test/topic_statistics_collector/test_subscriber_topic_statistics.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_subscriber_topic_statistics.cpp
@@ -305,7 +305,7 @@ TEST_F(SubscriberTopicStatisticsNodeTestFixture, TestSubscriptionCallback) {
 
   // check we have at least published once
   EXPECT_EQ(test_topic_stats_node_->GetNumPublished(), 1);
-  // check that IMU data was actually published
+  // check that dummy data was actually published
   EXPECT_GT(dummy_publisher_->GetNumberPublished(), 0);
 
   const auto all_collected_data = test_topic_stats_node_->GetPublishedCollectorData();
@@ -415,7 +415,7 @@ TEST_F(SubscriberTopicStatisticsNodeTestFixture, TestMetricsMessagePublisher) {
     receive_messages->GetFuture(),
     kTestDuration);
 
-  // check that IMU data was actually published
+  // check that dummy data was actually published
   EXPECT_GT(dummy_publisher_->GetNumberPublished(), 0);
   // check that we actually received a message
   EXPECT_EQ(receive_messages->GetNumberOfMessagesReceived(), 1);

--- a/system_metrics_collector/test/topic_statistics_collector/test_subscriber_topic_statistics.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_subscriber_topic_statistics.cpp
@@ -428,6 +428,10 @@ TEST_F(SubscriberTopicStatisticsNodeTestFixture, TestMetricsMessagePublisher) {
       case StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT:
         EXPECT_GT(dummy_publisher_->GetNumberPublished(), 1) << "unexpected sample count";
         break;
+      default:
+        // do nothing, we don't check statistics validity here but at a minimum
+        // check that the sample count is at least non-zero
+        break;
     }
   }
 }


### PR DESCRIPTION
Closes #124. This refactors the topic statistics subscriber tests to use futures to signal successful events rather than waiting on timing conditions.

Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>