### PR TITLE
Allow topic statistics to subscribe to multiple topics

### DIFF
--- a/system_metrics_collector/share/system_metrics_collector/examples/topic_statistics_node.launch.py
+++ b/system_metrics_collector/share/system_metrics_collector/examples/topic_statistics_node.launch.py
@@ -26,13 +26,13 @@ from launch_ros.actions import Node
 
 # Launch argument names
 COLLECTOR_NODE_NAME = 'topic_statistics_node_name'
-MONITORED_TOPIC_NAME = 'collect_topic_name'
+MONITORED_TOPIC_NAME = 'collect_topic_names'
 PUBLISH_PERIOD_IN_MS = 'publish_period'
 PUBLISH_TOPIC_NAME = 'publish_topic_name'
 
 # Default argument values
 DEFAULT_COLLECTOR_NODE_NAME = 'topic_stats_collector'
-DEFAULT_MONITORED_TOPIC_NAME = 'dummy_topic'
+DEFAULT_MONITORED_TOPIC_NAME = ['dummy_topic']
 DEFAULT_PUBLISH_PERIOD_IN_MS = '30000'
 DEFAULT_PUBLISH_TOPIC = 'system_metrics'
 

--- a/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
@@ -57,7 +57,7 @@ public:
    * Constructs a SubscriberTopicStatisticsNode node.
    * The following parameter can be set via the rclcpp::NodeOptions:
    * `publish_period`: the period at which metrics are published
-   * `collect_topic_names`: the topic to subscribe to and collect statistics
+   * `collect_topic_names`: the topics to subscribe to and collect statistics
    * `publish_topic_name`: the topic to publish collected statistics to
    *
    * @param node_name the name of this node, it must be non-empty

--- a/system_metrics_collector/src/topic_statistics_collector/topic_statistics_node.cpp
+++ b/system_metrics_collector/src/topic_statistics_collector/topic_statistics_node.cpp
@@ -14,6 +14,8 @@
 
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -52,9 +54,10 @@ public:
 
   void run()
   {
+    std::vector<std::string> topic_name = {"dummy_data"};
     const auto options = rclcpp::NodeOptions().append_parameter_override(
       constants::kCollectStatsTopicNameParam,
-      "dummy_data" /* The topic to which dummy data is published by dummy_talker. */);
+      topic_name /* The topic to which dummy data is published by dummy_talker. */);
     topic_stats_node_ = std::make_shared<SubscriberTopicStatisticsNode<DummyMessage>>(
       "topic_statistics_collector", options);
 

--- a/system_metrics_collector/test/topic_statistics_collector/test_subscriber_topic_statistics.cpp
+++ b/system_metrics_collector/test/topic_statistics_collector/test_subscriber_topic_statistics.cpp
@@ -202,7 +202,8 @@ public:
       system_metrics_collector::collector_node_constants::kPublishPeriodParam,
       kTopicPublishPeriod.count());
     // set the topic to collect statistics (listen)
-    options.append_parameter_override(constants::kCollectStatsTopicNameParam, kTestTopicName);
+    std::vector<std::string> test_topicname = {kTestTopicName};
+    options.append_parameter_override(constants::kCollectStatsTopicNameParam, test_topicname);
 
     dummy_publisher_ = std::make_shared<DummyMessagePublisher>();
     EXPECT_EQ(dummy_publisher_->getSubscriptionCount(), 0);
@@ -374,11 +375,25 @@ TEST_F(RclcppFixture, TestConstructorPublishPeriodValidation) {
 
 TEST_F(RclcppFixture, TestConstructorTopicNameValidation) {
   rclcpp::NodeOptions options;
-  options.append_parameter_override(constants::kCollectStatsTopicNameParam, std::string());
+  options.append_parameter_override(
+    constants::kCollectStatsTopicNameParam,
+    std::vector<std::string>());
 
   EXPECT_THROW(
     TestSubscriberTopicStatisticsNode("throw", options),
     std::invalid_argument);
+}
+
+TEST_F(SubscriberTopicStatisticsNodeTestFixture, TestConstructorTopicNameVectorValues) {
+  rclcpp::NodeOptions options;
+  std::vector<std::string> test_topicname = {kTestTopicName};
+  options.append_parameter_override(
+    constants::kCollectStatsTopicNameParam,
+    test_topicname);
+  topic_statistics_collector::SubscriberTopicStatisticsNode<DummyMessage> topic_statistics(
+    "TestConstructorTopicNameVectorValues",
+    options);
+  EXPECT_EQ(test_topicname, topic_statistics.GetCollectTopicName());
 }
 
 TEST_F(SubscriberTopicStatisticsNodeTestFixture, TestMetricsMessagePublisher) {
@@ -388,7 +403,8 @@ TEST_F(SubscriberTopicStatisticsNodeTestFixture, TestMetricsMessagePublisher) {
     system_metrics_collector::collector_node_constants::kPublishPeriodParam,
     kTopicPublishPeriod.count());
   // set the topic to collect statistics (listen)
-  options.append_parameter_override(constants::kCollectStatsTopicNameParam, kTestTopicName);
+  std::vector<std::string> test_topicname = {kTestTopicName};
+  options.append_parameter_override(constants::kCollectStatsTopicNameParam, test_topicname);
 
   const auto receive_messages = std::make_shared<test_functions::MetricsMessageSubscriber>(
     "TestMetricsMessagePublisher_listener",


### PR DESCRIPTION
Currently, the SubscriberTopicStatisticsNode class subscribes to only one topic for statistics collection. So, modified it to be able to subscribe and report statistics on multiple topics.

Fixes #118 