### PR TITLE
Bump setup_ros version to fix test failure

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: ros-tooling/setup-ros@0.0.20
+      - uses: ros-tooling/setup-ros@0.0.21
       - uses: ros-tooling/action-ros-ci@0.0.16
         with:
           package-name: system_metrics_collector


### PR DESCRIPTION
If tests pass, replaces https://github.com/ros-tooling/system_metrics_collector/pull/149 - haven't yet figured out the path requirements for that, this is a more minimal change.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>