### PR TITLE
Fix 'test_subscriber_topic_statistics' must be a valid target name build failure

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -147,10 +147,11 @@ if(BUILD_TESTING)
           test/topic_statistics_collector/test_subscriber_topic_statistics.cpp)
   target_link_libraries(test_subscriber_topic_statistics ${PROJECT_NAME})
   ament_target_dependencies(test_subscriber_topic_statistics rcl rclcpp)
+
+  rosidl_target_interfaces(test_subscriber_topic_statistics system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 endif()
 
 # To enable use of dummy_message.hpp in executables
-rosidl_target_interfaces(test_subscriber_topic_statistics system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 rosidl_target_interfaces(dummy_talker system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 rosidl_target_interfaces(topic_statistics_node system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 


### PR DESCRIPTION
As seen [here](http://build.ros2.org/view/Fdev/job/Fdev__system_metrics_collector__ubuntu_focal_amd64/1/console), building this package with 

`colcon build --build-base build_isolated --install-base install_isolated --test-result-base test_results --event-handlers console_cohesion+ --cmake-args -DBUILD_TESTING=0` 

throws the following error: 

```
06:44:21 --- stderr: system_metrics_collector
06:44:21 CMake Error at /opt/ros/foxy/share/rosidl_cmake/cmake/rosidl_target_interfaces.cmake:37 (message):
06:44:21   rosidl_target_interfaces() the first argument
06:44:21   'test_subscriber_topic_statistics' must be a valid target name
06:44:21 Call Stack (most recent call first):
06:44:21   CMakeLists.txt:153 (rosidl_target_interfaces)
06:44:21 
06:44:21 
06:44:21 ---
```

This is because `test_subscriber_topic_statistics` is non existent when `BUILD_TESTING` is `false`. 

Fix includes moving the following inside the `BUILD_TESTING` block.

```
rosidl_target_interfaces(test_subscriber_topic_statistics system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
```