### PR TITLE
[Foxy backport] Fix 'test_subscriber_topic_statistics' must be a valid target name build failure (#175)

### DIFF
--- a/system_metrics_collector/CMakeLists.txt
+++ b/system_metrics_collector/CMakeLists.txt
@@ -147,10 +147,11 @@ if(BUILD_TESTING)
           test/topic_statistics_collector/test_subscriber_topic_statistics.cpp)
   target_link_libraries(test_subscriber_topic_statistics ${PROJECT_NAME})
   ament_target_dependencies(test_subscriber_topic_statistics rcl rclcpp)
+
+  rosidl_target_interfaces(test_subscriber_topic_statistics system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 endif()
 
 # To enable use of dummy_message.hpp in executables
-rosidl_target_interfaces(test_subscriber_topic_statistics system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 rosidl_target_interfaces(dummy_talker system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 rosidl_target_interfaces(topic_statistics_node system_metrics_collector_test_msgs "rosidl_typesupport_cpp")
 


### PR DESCRIPTION
Backporting #175 into Foxy

Signed-off-by: Jaison Titus <jaisontj@amazon.com>
(cherry picked from commit 1c8b25c312047abb3c67817a8d1264bef9302e0d)