### PR TITLE
Fix build error and warning with latest version of core

### DIFF
--- a/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
+++ b/system_metrics_collector/src/system_metrics_collector/periodic_measurement_node.cpp
@@ -172,7 +172,7 @@ void PeriodicMeasurementNode::PerformPeriodicMeasurement()
   RCLCPP_DEBUG(this->get_logger(), "PerformPeriodicMeasurement: %f", measurement);
 
   AcceptData(measurement);
-  RCLCPP_DEBUG(this->get_logger(), GetStatusString());
+  RCLCPP_DEBUG(this->get_logger(), GetStatusString().c_str());
 }
 
 void PeriodicMeasurementNode::PublishStatisticMessage()

--- a/system_metrics_collector/src/topic_statistics_collector/dummy_talker.cpp
+++ b/system_metrics_collector/src/topic_statistics_collector/dummy_talker.cpp
@@ -40,7 +40,7 @@ public:
         msg_->header.stamp = this->now();
         RCLCPP_INFO(
           this->get_logger(),
-          "Publishing header: %lu",
+          "Publishing header: %u",
           msg_->header.stamp.nanosec);
 
         publisher_->publish(std::move(msg_));

--- a/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
+++ b/system_metrics_collector/src/topic_statistics_collector/subscriber_topic_statistics.hpp
@@ -100,7 +100,7 @@ public:
 
     auto callback = [this](typename T::SharedPtr received_message) {
         for (const auto & collector : statistics_collectors_) {
-          RCLCPP_DEBUG(this->get_logger(), collector->GetStatusString());
+          RCLCPP_DEBUG(this->get_logger(), collector->GetStatusString().c_str());
           collector->OnMessageReceived(*received_message, this->LifecycleNode::now().nanoseconds());
         }
       };


### PR DESCRIPTION
After https://github.com/ros2/rclcpp/pull/1442 - `RCLCPP_DEBUG` no longer accepts `std::string`, so we need to update those places to pass `const char *`.

(side note there was a build warning for the other string format - and I didn't want to have a PR with warnings)