### PR TITLE
Disable dependabot after project deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   schedule:
     interval: daily
     time: "16:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0


### PR DESCRIPTION
See https://github.com/ros-tooling/community/pull/34

I set the PR limit to `0` but otherwise kept the file as-is. 

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>