### PR TITLE
Remove CloudWatch reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,29 +49,3 @@ jobs:
       with:
         name: colcon-logs-ubuntu-asan
         path: ros_ws/log
-
-  log_workflow_status_to_cloudwatch:
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:bionic
-    needs:
-    - build_and_test_ubuntu
-    - build_and_test_asan
-    # Don't skip if prior steps failed, but don't run on a fork because it won't have access to AWS secrets
-    if: ${{ always() && ! github.event.repository.fork && ! github.event.pull_request.head.repo.fork }}
-    steps:
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
-    - uses: ros-tooling/action-cloudwatch-metrics@0.0.5
-      with:
-        # Checks if any of the jobs have failed.
-        #
-        # needs.*.result is returns the list of all success statuses as an
-        # array, i.e. ['success', 'failure, 'success']
-        # join() converts the array to a string 'successfailuresuccess'
-        # contains() checks whether the string contains failure
-        metric-value: ${{ ! contains(join(needs.*.result, ''), 'failure') && ! contains(join(needs.*.result, ''), 'cancelled') }}


### PR DESCRIPTION
This isn't providing value to the open source community - simplifying workflows by removing this AWS-specific configuration